### PR TITLE
Changing the reference schema for Netlify CMS

### DIFF
--- a/_includes/references.html
+++ b/_includes/references.html
@@ -2,7 +2,9 @@
   <h2>References</h2>
   <ul>
   {% for ref in include.page.references %}
-    <li>{{ ref | markdownify | remove: "<p>" | remove: "</p>" }}</li>
+    {% assign link_parts_1 = ref.link_url | split: "://" %}
+    {% assign link_base_url = link_parts_1[1] | split: "/" | first %}
+    <li><a href="{{ ref.link_url }}">{{ ref.link_title }} <code>({{ link_base_url }})</code></a></li>
   {% endfor %}
   </ul>
 {% endif %}

--- a/css/customstyle.css
+++ b/css/customstyle.css
@@ -62,6 +62,10 @@ a:focus   {
   outline: 1px dotted currentColor;
 }
 
+a > code {
+  font-size: x-small;
+}
+
 /* Style for images and figures */
 
 figure {

--- a/terms/1-bit-stochastic-gradient-descent-1-bit-sgd.md
+++ b/terms/1-bit-stochastic-gradient-descent-1-bit-sgd.md
@@ -1,12 +1,14 @@
 ---
-title: 1-bit Stochastic Gradient Descent (1-bit SGD)
-related_terms:
- - backpropagation
- - stochastic-gradient-descent-sgd
- - optimization
- - data-parallelism
 references:
- - "[1-Bit Stochastic Gradient Descent and Application to Data-Parallel Distributed Training of Speech DNNs](https://www.microsoft.com/en-us/research/publication/1-bit-stochastic-gradient-descent-and-application-to-data-parallel-distributed-training-of-speech-dnns/)"
+- link_title: 1-Bit Stochastic Gradient Descent and Application to Data-Parallel Distributed
+    Training of Speech DNNs
+  link_url: https://www.microsoft.com/en-us/research/publication/1-bit-stochastic-gradient-descent-and-application-to-data-parallel-distributed-training-of-speech-dnns/
+related_terms:
+- backpropagation
+- stochastic-gradient-descent-sgd
+- optimization
+- data-parallelism
+title: 1-bit Stochastic Gradient Descent (1-bit SGD)
 ---
 1-bit Stochastic Gradient Descent is a technique from Microsoft Research aimed at
 increasing the [data parallelism][1] inherent in training deep neural networks.

--- a/terms/1x1-convolution.md
+++ b/terms/1x1-convolution.md
@@ -1,12 +1,14 @@
 ---
-title: 1x1 Convolution
-related_terms:
- - convolutional-neural-network-cnn
- - convolution
- - filter-convolution
 references:
- - "[Network In Network](https://arxiv.org/abs/1312.4400)"
- - "[Going Deeper With Convolutions](http://www.cs.unc.edu/~wliu/papers/GoogLeNet.pdf)"
+- link_title: Network In Network
+  link_url: https://arxiv.org/abs/1312.4400
+- link_title: Going Deeper With Convolutions
+  link_url: http://www.cs.unc.edu/~wliu/papers/GoogLeNet.pdf
+related_terms:
+- convolutional-neural-network-cnn
+- convolution
+- filter-convolution
+title: 1x1 Convolution
 ---
 A *1x1 convolution* or a *network in network* is
 an architectural technique used in some convolutional

--- a/terms/accams.md
+++ b/terms/accams.md
@@ -1,8 +1,9 @@
 ---
-title: ACCAMS
-related_terms:
- - co-clustering
 references:
- - "[ACCAMS: Additive Co-Clustering to Approximate Matrices Succinctly](http://arxiv.org/abs/1501.00199)"
+- link_title: 'ACCAMS: Additive Co-Clustering to Approximate Matrices Succinctly'
+  link_url: http://arxiv.org/abs/1501.00199
+related_terms:
+- co-clustering
+title: ACCAMS
 ---
 ACCAMS: Additive Co-Clustering to Approximate Matrices Succinctly

--- a/terms/activation-function.md
+++ b/terms/activation-function.md
@@ -1,10 +1,12 @@
 ---
-title: Activation function
-related_terms:
- - neural-network
 references:
- - "[Activation function - Wikipedia](https://en.wikipedia.org/wiki/Activation_function)"
- - "[Commonly used activation functions - Stanford CS231n notes](http://cs231n.github.io/neural-networks-1/#actfun)"
+- link_title: Activation function - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Activation_function
+- link_title: Commonly used activation functions - Stanford CS231n notes
+  link_url: http://cs231n.github.io/neural-networks-1/#actfun
+related_terms:
+- neural-network
+title: Activation function
 ---
 In neural networks, an activation function defines
 the output of a neuron.

--- a/terms/adadelta.md
+++ b/terms/adadelta.md
@@ -1,12 +1,13 @@
 ---
-title: ADADELTA
-related_terms:
- - learning-rate
- - adam-optimizer
- - adagrad
- - stochastic-gradient-descent-sgd
 references:
- - "[ADADELTA: An Adaptive Learning Rate Method](https://arxiv.org/abs/1212.5701)"
+- link_title: 'ADADELTA: An Adaptive Learning Rate Method'
+  link_url: https://arxiv.org/abs/1212.5701
+related_terms:
+- learning-rate
+- adam-optimizer
+- adagrad
+- stochastic-gradient-descent-sgd
+title: ADADELTA
 ---
 ADADELTA is a gradient descent-based optimization algorithm. Like [AdaGrad][1],
 ADADELTA automatically tunes the learning rate.

--- a/terms/adagrad.md
+++ b/terms/adagrad.md
@@ -1,12 +1,15 @@
 ---
-title: AdaGrad
-related_terms:
- - stochastic-gradient-descent-sgd
- - momentum-optimization
- - learning-rate
 references:
- - "[Adaptive Subgradient Methods for Online Learning and Stochastic Optimization](http://jmlr.org/papers/v12/duchi11a.html)"
- - "[An overview of gradient descent optimization algorithms - Sebiastian Ruder](http://sebastianruder.com/optimizing-gradient-descent/)"
+- link_title: Adaptive Subgradient Methods for Online Learning and Stochastic Optimization
+  link_url: http://jmlr.org/papers/v12/duchi11a.html
+- link_title: An overview of gradient descent optimization algorithms - Sebiastian
+    Ruder
+  link_url: http://sebastianruder.com/optimizing-gradient-descent/
+related_terms:
+- stochastic-gradient-descent-sgd
+- momentum-optimization
+- learning-rate
+title: AdaGrad
 ---
 AdaGrad is a gradient-descent based optimization algorithm. It automatically
 tunes the [learning rate][1] based on its observations of the data's geometry.

--- a/terms/adam-optimizer.md
+++ b/terms/adam-optimizer.md
@@ -1,15 +1,17 @@
 ---
-title: ADAM Optimizer
-related_terms:
- - adagrad
- - rmsprop
- - stochastic-optimization
- - stochastic-gradient-descent-sgd
 references:
- - "[Adam: A Method for Stochastic Optimization](https://arxiv.org/abs/1412.6980)"
- - "[ADAM - An overview of gradient descent optimization algorithms - Sebastian Ruder](http://sebastianruder.com/optimizing-gradient-descent/index.html#adam)"
+- link_title: 'Adam: A Method for Stochastic Optimization'
+  link_url: https://arxiv.org/abs/1412.6980
+- link_title: ADAM - An overview of gradient descent optimization algorithms - Sebastian
+    Ruder
+  link_url: http://sebastianruder.com/optimizing-gradient-descent/index.html#adam
+related_terms:
+- adagrad
+- rmsprop
+- stochastic-optimization
+- stochastic-gradient-descent-sgd
+title: ADAM Optimizer
 ---
-
 ADAM, or **Ada**ptive **M**oment Estimation, is a stochastic optimization
 method [introduced by Diederik P. Kingma and Jimmy Lei Ba][5].
 

--- a/terms/additive-model.md
+++ b/terms/additive-model.md
@@ -1,5 +1,6 @@
 ---
-title: Additive model
 references:
- - "[Additive model - Wikipedia](https://en.wikipedia.org/wiki/Additive_model)"
+- link_title: Additive model - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Additive_model
+title: Additive model
 ---

--- a/terms/adversarial-autoencoder.md
+++ b/terms/adversarial-autoencoder.md
@@ -1,9 +1,10 @@
 ---
-title: Adversarial autoencoder
-related_terms:
- - autoencoder
- - generative-adversarial-network-gan
- - variational-autoencoder-vae
 references:
- - "[Adversarial Autoencoders](https://arxiv.org/abs/1511.05644)"
+- link_title: Adversarial Autoencoders
+  link_url: https://arxiv.org/abs/1511.05644
+related_terms:
+- autoencoder
+- generative-adversarial-network-gan
+- variational-autoencoder-vae
+title: Adversarial autoencoder
 ---

--- a/terms/adversarial-variational-bayes.md
+++ b/terms/adversarial-variational-bayes.md
@@ -1,10 +1,12 @@
 ---
-title: Adversarial Variational Bayes
-related_terms:
- - autoencoder
- - adversarial-autoencoder
- - variational-autoencoder-vae
- - generative-adversarial-network-gan
 references:
- - "[Adversarial Variational Bayes: Unifying Variational Autoencoders and Generative Adversarial Networks](https://arxiv.org/abs/1701.04722)"
+- link_title: 'Adversarial Variational Bayes: Unifying Variational Autoencoders and
+    Generative Adversarial Networks'
+  link_url: https://arxiv.org/abs/1701.04722
+related_terms:
+- autoencoder
+- adversarial-autoencoder
+- variational-autoencoder-vae
+- generative-adversarial-network-gan
+title: Adversarial Variational Bayes
 ---

--- a/terms/affinity-analysis.md
+++ b/terms/affinity-analysis.md
@@ -1,5 +1,6 @@
 ---
-title: Affinity analysis
 references:
- - "[Affinity analysis - Wikipedia](https://en.wikipedia.org/wiki/Affinity_analysis)"
+- link_title: Affinity analysis - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Affinity_analysis
+title: Affinity analysis
 ---

--- a/terms/affinity-propagation-clustering.md
+++ b/terms/affinity-propagation-clustering.md
@@ -1,7 +1,8 @@
 ---
-title: Affinity propagation clustering
-related_terms:
- - clustering
 references:
- - "[Affinity propagation](https://en.wikipedia.org/wiki/Affinity_propagation)"
+- link_title: Affinity propagation
+  link_url: https://en.wikipedia.org/wiki/Affinity_propagation
+related_terms:
+- clustering
+title: Affinity propagation clustering
 ---

--- a/terms/alexnet.md
+++ b/terms/alexnet.md
@@ -1,9 +1,10 @@
 ---
-title: AlexNet
-related_terms:
- - convolutional-neural-network-cnn
 references:
- - "[ImageNet Classification with Deep Convolutional Neural Networks](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf)"
+- link_title: ImageNet Classification with Deep Convolutional Neural Networks
+  link_url: https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf
+related_terms:
+- convolutional-neural-network-cnn
+title: AlexNet
 ---
 AlexNet is a convolutional neural network architecture proposed by
 Alex Krizhevsky, Ilya Sutskever, and Geoffrey Hinton in 2012.

--- a/terms/alternating-conditional-expectation-ace-algorithm.md
+++ b/terms/alternating-conditional-expectation-ace-algorithm.md
@@ -1,8 +1,9 @@
 ---
-title: Alternating conditional expectation (ACE) algorithm
-related_terms:
- - nonparametric-regression
 references:
- - "[Estimating Optimal Transformations for Multiple
-Regression Using the ACE Algorithm](http://www.jds-online.com/files/JDS-156.pdf)"
+- link_title: Estimating Optimal Transformations for Multiple Regression Using the
+    ACE Algorithm
+  link_url: http://www.jds-online.com/files/JDS-156.pdf
+related_terms:
+- nonparametric-regression
+title: Alternating conditional expectation (ACE) algorithm
 ---

--- a/terms/association-rule-mining.md
+++ b/terms/association-rule-mining.md
@@ -1,6 +1,8 @@
 ---
-title: Association rule mining
 references:
- - "[Association rule learning - Wikipedia](https://en.wikipedia.org/wiki/Association_rule_learning)"
- - "[Mining association rules between sets of items in large databases](http://dl.acm.org/citation.cfm?doid=170035.170072)"
+- link_title: Association rule learning - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Association_rule_learning
+- link_title: Mining association rules between sets of items in large databases
+  link_url: http://dl.acm.org/citation.cfm?doid=170035.170072
+title: Association rule mining
 ---

--- a/terms/autocorrelation-matrix.md
+++ b/terms/autocorrelation-matrix.md
@@ -1,5 +1,6 @@
 ---
-title: Autocorrelation matrix
 references:
- - "[Autocorrelation matrix - Wikipedia](https://en.wikipedia.org/wiki/Autocorrelation_matrix)"
+- link_title: Autocorrelation matrix - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Autocorrelation_matrix
+title: Autocorrelation matrix
 ---

--- a/terms/autoencoder.md
+++ b/terms/autoencoder.md
@@ -1,11 +1,14 @@
 ---
-title: Autoencoder
-related_terms:
- - representation-learning
 references:
- - "[Autoencoder - Wikipedia](https://en.wikipedia.org/wiki/Autoencoder)"
- - "[Autoencoders - Deep Learning Tutorial](http://deeplearning.net/tutorial/dA.html#autoencoders)"
- - "[What is the difference between an autoencoder and a neural network?](https://www.quora.com/What-is-the-difference-between-a-neural-network-and-an-autoencoder-network/answer/Patrick-Hall-4)"
+- link_title: Autoencoder - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Autoencoder
+- link_title: Autoencoders - Deep Learning Tutorial
+  link_url: http://deeplearning.net/tutorial/dA.html#autoencoders
+- link_title: What is the difference between an autoencoder and a neural network?
+  link_url: https://www.quora.com/What-is-the-difference-between-a-neural-network-and-an-autoencoder-network/answer/Patrick-Hall-4
+related_terms:
+- representation-learning
+title: Autoencoder
 ---
 Autoencoders are an [unsupervised learning][1] model that aim to learn
 [distributed representations][2] of data.

--- a/terms/backpropagation-through-time-bptt.md
+++ b/terms/backpropagation-through-time-bptt.md
@@ -1,8 +1,9 @@
 ---
-title: Backpropagation Through Time (BPTT)
-related_terms:
- - backpropagation
- - recurrent-neural-network
 references:
- - "[Backpropagation through time - Wikipedia](https://en.wikipedia.org/wiki/Backpropagation_through_time)"
+- link_title: Backpropagation through time - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Backpropagation_through_time
+related_terms:
+- backpropagation
+- recurrent-neural-network
+title: Backpropagation Through Time (BPTT)
 ---

--- a/terms/backpropagation.md
+++ b/terms/backpropagation.md
@@ -1,8 +1,10 @@
 ---
-title: Backpropagation
-related_terms:
- - gradient-descent
 references:
- - "[Yes you should understand backprop - Andrej Karpathy](https://medium.com/@karpathy/yes-you-should-understand-backprop-e2f06eab496b)"
- - "[Backpropagation - Wikipedia](https://en.wikipedia.org/wiki/Backpropagation)"
+- link_title: Yes you should understand backprop - Andrej Karpathy
+  link_url: https://medium.com/@karpathy/yes-you-should-understand-backprop-e2f06eab496b
+- link_title: Backpropagation - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Backpropagation
+related_terms:
+- gradient-descent
+title: Backpropagation
 ---

--- a/terms/bag-of-words.md
+++ b/terms/bag-of-words.md
@@ -1,8 +1,10 @@
 ---
-title: Bag-of-words
 references:
- - "[Bag-of-words model - Wikipedia](https://en.wikipedia.org/wiki/Bag-of-words_model)"
- - "[Bag of Words Meets Bags of Popcorn - Kaggle](https://www.kaggle.com/c/word2vec-nlp-tutorial/details/part-1-for-beginners-bag-of-words)"
+- link_title: Bag-of-words model - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Bag-of-words_model
+- link_title: Bag of Words Meets Bags of Popcorn - Kaggle
+  link_url: https://www.kaggle.com/c/word2vec-nlp-tutorial/details/part-1-for-beginners-bag-of-words
+title: Bag-of-words
 ---
 The phrase *bag-of-words* typically refers to a way of representing
 text in natural language processing, although [it has been applied to computer vision][1].

--- a/terms/batch-normalization.md
+++ b/terms/batch-normalization.md
@@ -1,8 +1,13 @@
 ---
-title: Batch normalization
 references:
- - "[Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167)"
- - "[Batch Normalization — What the hey?](https://gab41.lab41.org/batch-normalization-what-the-hey-d480039a9e3b)"
- - "[Why does batch normalization help? - Quora](https://www.quora.com/Why-does-batch-normalization-help)"
- - "[Understanding the backward pass through Batch Normalization Layer](http://kratzert.github.io/2016/02/12/understanding-the-gradient-flow-through-the-batch-normalization-layer.html)"
+- link_title: 'Batch Normalization: Accelerating Deep Network Training by Reducing
+    Internal Covariate Shift'
+  link_url: https://arxiv.org/abs/1502.03167
+- link_title: "Batch Normalization\u200A\u2014\u200AWhat the hey?"
+  link_url: https://gab41.lab41.org/batch-normalization-what-the-hey-d480039a9e3b
+- link_title: Why does batch normalization help? - Quora
+  link_url: https://www.quora.com/Why-does-batch-normalization-help
+- link_title: Understanding the backward pass through Batch Normalization Layer
+  link_url: http://kratzert.github.io/2016/02/12/understanding-the-gradient-flow-through-the-batch-normalization-layer.html
+title: Batch normalization
 ---

--- a/terms/beam-search.md
+++ b/terms/beam-search.md
@@ -1,11 +1,14 @@
 ---
-title: Beam search
-related_terms:
- - recurrent-neural-network
- - sequence-to-sequence-learning-seq2seq
 references:
- - "[Beam search - Wikipedia](https://en.wikipedia.org/wiki/Beam_search)"
- - "[Why is beam search required in sequence-to-sequence transduction using recurrent neural networks? - Quora](https://www.quora.com/Why-is-beam-search-required-in-sequence-to-sequence-transduction-using-recurrent-neural-networks)"
+- link_title: Beam search - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Beam_search
+- link_title: Why is beam search required in sequence-to-sequence transduction using
+    recurrent neural networks? - Quora
+  link_url: https://www.quora.com/Why-is-beam-search-required-in-sequence-to-sequence-transduction-using-recurrent-neural-networks
+related_terms:
+- recurrent-neural-network
+- sequence-to-sequence-learning-seq2seq
+title: Beam search
 ---
 Beam search is a memory-restricted version of breadth-first search.
 

--- a/terms/bias-variance-tradeoff.md
+++ b/terms/bias-variance-tradeoff.md
@@ -1,14 +1,15 @@
 ---
-title: Bias-variance tradeoff
-related_terms:
- - regularization
- - variance
- - bias
- - supervised-learning
- - underfitting
- - overfitting
 references:
- - "[Bias-variance tradeoff - Wikipedia](https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff)"
+- link_title: Bias-variance tradeoff - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Bias%E2%80%93variance_tradeoff
+related_terms:
+- regularization
+- variance
+- bias
+- supervised-learning
+- underfitting
+- overfitting
+title: Bias-variance tradeoff
 ---
 The bias-variance tradeoff refers to the problem of minimizing two different sources of error
 when training a supervised learning model:

--- a/terms/bias.md
+++ b/terms/bias.md
@@ -1,8 +1,10 @@
 ---
-title: Bias
-related_terms:
- - variance
 references:
- - "[Bias of an estimator - Wikipedia](https://en.wikipedia.org/wiki/Bias_of_an_estimator)"
- - "[Bias (statistics) - Wikipedia](https://en.wikipedia.org/wiki/Bias_(statistics))"
+- link_title: Bias of an estimator - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Bias_of_an_estimator
+- link_title: Bias (statistics) - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Bias_(statistics
+related_terms:
+- variance
+title: Bias
 ---

--- a/terms/binary-tree-lstm.md
+++ b/terms/binary-tree-lstm.md
@@ -1,8 +1,10 @@
 ---
-title: Binary Tree LSTM
-related_terms:
- - long-short-term-memory-lstm
- - tree-lstm
 references:
- - "[Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks](https://arxiv.org/abs/1503.00075)"
+- link_title: Improved Semantic Representations From Tree-Structured Long Short-Term
+    Memory Networks
+  link_url: https://arxiv.org/abs/1503.00075
+related_terms:
+- long-short-term-memory-lstm
+- tree-lstm
+title: Binary Tree LSTM
 ---

--- a/terms/burstiness.md
+++ b/terms/burstiness.md
@@ -1,8 +1,9 @@
 ---
-title: Burstiness
 needs_review: true
 references:
- - "[Burstiness - Wikipedia](https://en.wikipedia.org/wiki/Burstiness)"
+- link_title: Burstiness - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Burstiness
+title: Burstiness
 ---
 Wikipedia defines burstiness as follows:
 

--- a/terms/catastrophic-forgetting.md
+++ b/terms/catastrophic-forgetting.md
@@ -1,10 +1,15 @@
 ---
-title: Catastrophic forgetting
 references:
- - "[Overcoming catastrophic forgetting in neural networks](https://arxiv.org/abs/1612.00796)"
- - "[Catastrophic interference - Wikipedia](https://en.wikipedia.org/wiki/Catastrophic_interference)"
- - "[Catastrophic forgetting - Standout Publishing](http://standoutpublishing.com/g/catastrophic-forgetting.html)"
- - "[Catastrophic Interference in Connectionist Networks: The Sequential Learning Problem](http://www.sciencedirect.com/science/article/pii/S0079742108605368)"
+- link_title: Overcoming catastrophic forgetting in neural networks
+  link_url: https://arxiv.org/abs/1612.00796
+- link_title: Catastrophic interference - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Catastrophic_interference
+- link_title: Catastrophic forgetting - Standout Publishing
+  link_url: http://standoutpublishing.com/g/catastrophic-forgetting.html
+- link_title: 'Catastrophic Interference in Connectionist Networks: The Sequential
+    Learning Problem'
+  link_url: http://www.sciencedirect.com/science/article/pii/S0079742108605368
+title: Catastrophic forgetting
 ---
 Catastrophic forgetting (or catastrophic interference) is a problem
 in machine learning where a model forgets an existing learned pattern

--- a/terms/child-sum-tree-lstm.md
+++ b/terms/child-sum-tree-lstm.md
@@ -1,8 +1,10 @@
 ---
-title: Child-Sum Tree-LSTM
-related_terms:
- - long-short-term-memory-lstm
- - tree-lstm
 references:
- - "[Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks](https://arxiv.org/abs/1503.00075)"
+- link_title: Improved Semantic Representations From Tree-Structured Long Short-Term
+    Memory Networks
+  link_url: https://arxiv.org/abs/1503.00075
+related_terms:
+- long-short-term-memory-lstm
+- tree-lstm
+title: Child-Sum Tree-LSTM
 ---

--- a/terms/co-adaptation.md
+++ b/terms/co-adaptation.md
@@ -1,10 +1,11 @@
 ---
-title: Co-adaptation
-related_terms:
- - dropout
- - regularization
 references:
- - '[What does "co-adaptation of neurons" in a Neural network mean? - Quora](https://www.quora.com/What-does-co-adaptation-of-neurons-in-a-Neural-network-mean)'
+- link_title: What does "co-adaptation of neurons" in a Neural network mean? - Quora
+  link_url: https://www.quora.com/What-does-co-adaptation-of-neurons-in-a-Neural-network-mean
+related_terms:
+- dropout
+- regularization
+title: Co-adaptation
 ---
 In neural networks, co-adaptation refers to when different hidden
 units in a neural networks have highly correlated behavior.

--- a/terms/community-structure.md
+++ b/terms/community-structure.md
@@ -1,8 +1,9 @@
 ---
-title: Community structure
-related_terms:
- - stochastic-block-model-sbm
- - clustering
 references:
- - "[Community structure - Wikipedia](https://en.wikipedia.org/wiki/Community_structure)"
+- link_title: Community structure - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Community_structure
+related_terms:
+- stochastic-block-model-sbm
+- clustering
+title: Community structure
 ---

--- a/terms/computer-vision.md
+++ b/terms/computer-vision.md
@@ -1,7 +1,8 @@
 ---
-title: Computer vision
 references:
- - "[Computer vision - Wikipedia](https://en.wikipedia.org/wiki/Computer_vision)"
+- link_title: Computer vision - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Computer_vision
+title: Computer vision
 ---
 Computer vision is the field of teaching computers to perceive sensor
 data--such as from cameras, RADAR, and LIDAR sensors--to achieve

--- a/terms/connectionism.md
+++ b/terms/connectionism.md
@@ -1,7 +1,8 @@
 ---
-title: Connectionism
-related_terms:
- - neural-network
 references:
- - "[Connectionism - Wikipedia](https://en.wikipedia.org/wiki/Connectionism)"
+- link_title: Connectionism - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Connectionism
+related_terms:
+- neural-network
+title: Connectionism
 ---

--- a/terms/connectionist-temporal-classification-ctc.md
+++ b/terms/connectionist-temporal-classification-ctc.md
@@ -1,10 +1,12 @@
 ---
-title: Connectionist Temporal Classification (CTC)
-related_terms:
- - recurrent-neural-network
- - temporal-classification
 references:
- - "[Connectionist Temporal Classification: Labelling Unsegmented Sequence Data with Recurrent Neural Networks](http://www.machinelearning.org/proceedings/icml2006/047_Connectionist_Tempor.pdf)"
+- link_title: 'Connectionist Temporal Classification: Labelling Unsegmented Sequence
+    Data with Recurrent Neural Networks'
+  link_url: http://www.machinelearning.org/proceedings/icml2006/047_Connectionist_Tempor.pdf
+related_terms:
+- recurrent-neural-network
+- temporal-classification
+title: Connectionist Temporal Classification (CTC)
 ---
 *Connectionist Temporal Classification* is a term coined in a paper by
 Graves et al. titled [Connectionist Temporal Classification: Labelling Unsegmented Sequence Data with Recurrent Neural Networks][1].

--- a/terms/constituency-tree-lstm.md
+++ b/terms/constituency-tree-lstm.md
@@ -1,8 +1,10 @@
 ---
-title: Constituency Tree-LSTM
-related_terms:
- - long-short-term-memory-lstm
- - tree-lstm
 references:
- - "[Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks](https://arxiv.org/abs/1503.00075)"
+- link_title: Improved Semantic Representations From Tree-Structured Long Short-Term
+    Memory Networks
+  link_url: https://arxiv.org/abs/1503.00075
+related_terms:
+- long-short-term-memory-lstm
+- tree-lstm
+title: Constituency Tree-LSTM
 ---

--- a/terms/contextual-bandit.md
+++ b/terms/contextual-bandit.md
@@ -1,8 +1,10 @@
 ---
-title: Contextual Bandit
-related_terms:
- - multi-armed-bandit
 references:
- - "[Contextual Bandit - Multi-armed Bandit - Wikipedia](https://en.wikipedia.org/wiki/Multi-armed_bandit#Contextual_Bandit)"
- - "[An Introduction to Contextual Bandits - Stream](https://getstream.io/blog/introduction-contextual-bandits/)"
+- link_title: Contextual Bandit - Multi-armed Bandit - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Multi-armed_bandit#Contextual_Bandit
+- link_title: An Introduction to Contextual Bandits - Stream
+  link_url: https://getstream.io/blog/introduction-contextual-bandits/
+related_terms:
+- multi-armed-bandit
+title: Contextual Bandit
 ---

--- a/terms/convex-combination.md
+++ b/terms/convex-combination.md
@@ -1,9 +1,10 @@
 ---
-title: Convex combination
-related_terms:
- - convex-optimization
 references:
- - "[Convex combination - Wikipedia](https://en.wikipedia.org/wiki/Convex_combination)"
+- link_title: Convex combination - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Convex_combination
+related_terms:
+- convex-optimization
+title: Convex combination
 ---
 A convex combination is a linear combination, where all
 the coefficients are greater than 0 and sum to 1.

--- a/terms/convex-hull.md
+++ b/terms/convex-hull.md
@@ -1,12 +1,15 @@
 ---
-title: Convex hull
-related_terms:
- - convex-combination
- - affine-space
 references:
- - "[Convex hull - Wikipedia](https://en.wikipedia.org/wiki/Convex_hull)"
- - "[Convex set - Wikipedia](https://en.wikipedia.org/wiki/Convex_set)"
- - "[Convex combination - Wikipedia](https://en.wikipedia.org/wiki/Convex_combination)"
+- link_title: Convex hull - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Convex_hull
+- link_title: Convex set - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Convex_set
+- link_title: Convex combination - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Convex_combination
+related_terms:
+- convex-combination
+- affine-space
+title: Convex hull
 ---
 The convex hull of a set $X$ in an affine space over the reals is the smallest
 [convex set][1] that contains $X$. When the points are two dimensional,

--- a/terms/convolutional-neural-network-cnn.md
+++ b/terms/convolutional-neural-network-cnn.md
@@ -1,11 +1,14 @@
 ---
-title: Convolutional Neural Networks (CNN)
-related_terms:
- - convolution
- - attention-neural-networks
- - neural-network
 references:
- - "[Convolutional neural network - Wikipedia](https://en.wikipedia.org/wiki/Convolutional_neural_network)"
- - "[Stanford CS231n Convolutional Neural Networks for Visual Recognition](http://cs231n.github.io/convolutional-networks/)"
- - "[Understanding convolutional neural networks for NLP - WildML](http://www.wildml.com/2015/11/understanding-convolutional-neural-networks-for-nlp/)"
+- link_title: Convolutional neural network - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Convolutional_neural_network
+- link_title: Stanford CS231n Convolutional Neural Networks for Visual Recognition
+  link_url: http://cs231n.github.io/convolutional-networks/
+- link_title: Understanding convolutional neural networks for NLP - WildML
+  link_url: http://www.wildml.com/2015/11/understanding-convolutional-neural-networks-for-nlp/
+related_terms:
+- convolution
+- attention-neural-networks
+- neural-network
+title: Convolutional Neural Networks (CNN)
 ---

--- a/terms/covariate-shift.md
+++ b/terms/covariate-shift.md
@@ -1,7 +1,8 @@
 ---
-title: Covariate shift
-related_terms:
- - batch-normalization
 references:
- - "[Real simple covariate shift correction - Alex Smola](http://blog.smola.org/post/4110255196/real-simple-covariate-shift-correction)"
+- link_title: Real simple covariate shift correction - Alex Smola
+  link_url: http://blog.smola.org/post/4110255196/real-simple-covariate-shift-correction
+related_terms:
+- batch-normalization
+title: Covariate shift
 ---

--- a/terms/data-augmentation.md
+++ b/terms/data-augmentation.md
@@ -1,11 +1,15 @@
 ---
-title: Data augmentation
-related_terms:
- - overfitting
 references:
- - "[Data Augmentation - Convolutional Neural Networks - deeplearning.ai](https://www.coursera.org/learn/convolutional-neural-networks/lecture/AYzbX/data-augmentation)"
- - "[Understanding data augmentation for classification: when to warp?](https://arxiv.org/abs/1609.08764)"
- - "[What you need to know about data augmentation for machine learning - Cartesian Faith](https://cartesianfaith.com/2016/10/06/what-you-need-to-know-about-data-augmentation-for-machine-learning/)"
+- link_title: Data Augmentation - Convolutional Neural Networks - deeplearning.ai
+  link_url: https://www.coursera.org/learn/convolutional-neural-networks/lecture/AYzbX/data-augmentation
+- link_title: 'Understanding data augmentation for classification: when to warp?'
+  link_url: https://arxiv.org/abs/1609.08764
+- link_title: What you need to know about data augmentation for machine learning -
+    Cartesian Faith
+  link_url: https://cartesianfaith.com/2016/10/06/what-you-need-to-know-about-data-augmentation-for-machine-learning/
+related_terms:
+- overfitting
+title: Data augmentation
 ---
 *Data augmentation* is the process of using computer algorthms
 or other synthetic means to increase the size of a collected dataset.

--- a/terms/data-parallelism.md
+++ b/terms/data-parallelism.md
@@ -1,8 +1,11 @@
 ---
-title: Data parallelism
 references:
- - "[Data parallelism - Wikipedia](https://en.wikipedia.org/wiki/Data_parallelism)"
- - "[What is the difference between model parallelism and data parallelism? - Quora](https://www.quora.com/What-is-the-difference-between-model-parallelism-and-data-parallelism)"
+- link_title: Data parallelism - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Data_parallelism
+- link_title: What is the difference between model parallelism and data parallelism?
+    - Quora
+  link_url: https://www.quora.com/What-is-the-difference-between-model-parallelism-and-data-parallelism
+title: Data parallelism
 ---
 Data parallelism is when data is distributed across multiple
 nodes in a distributed computing environment, and then

--- a/terms/deep-convolutional-generative-adversarial-network-dcgan.md
+++ b/terms/deep-convolutional-generative-adversarial-network-dcgan.md
@@ -1,10 +1,12 @@
 ---
-title: Deep Convolutional Generative Adversarial Network (DCGAN)
-related_terms:
- - generative-adversarial-network-gan
- - convolutional-neural-network-cnn
 references:
- - "[Unsupervised Representation Learning with Deep Convolutional Generative Adversarial Networks](https://arxiv.org/abs/1511.06434)"
+- link_title: Unsupervised Representation Learning with Deep Convolutional Generative
+    Adversarial Networks
+  link_url: https://arxiv.org/abs/1511.06434
+related_terms:
+- generative-adversarial-network-gan
+- convolutional-neural-network-cnn
+title: Deep Convolutional Generative Adversarial Network (DCGAN)
 ---
 DCGAN refers to a model described by [Radford, Metz, and Chintala][1]
 that uses deep convolutional neural networks in a generative adversarial network model.

--- a/terms/dependency-tree-lstm.md
+++ b/terms/dependency-tree-lstm.md
@@ -1,8 +1,10 @@
 ---
-title: Dependency Tree LSTM
-related_terms:
- - long-short-term-memory-lstm
- - tree-lstm
 references:
- - "[Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks](https://arxiv.org/abs/1503.00075)"
+- link_title: Improved Semantic Representations From Tree-Structured Long Short-Term
+    Memory Networks
+  link_url: https://arxiv.org/abs/1503.00075
+related_terms:
+- long-short-term-memory-lstm
+- tree-lstm
+title: Dependency Tree LSTM
 ---

--- a/terms/derivative-free-optimization.md
+++ b/terms/derivative-free-optimization.md
@@ -1,9 +1,12 @@
 ---
-title: Derivative-free optimization
-related_terms:
- - optimization
- - black-box-optimization
 references:
- - "[Derivative-free optimization - Wikipedia](https://en.wikipedia.org/wiki/Derivative-free_optimization)"
- - "[Derivative-free optimization: A review of algorithms and comparison of software implementations](http://thales.cheme.cmu.edu/dfo/comparison/dfo.pdf)"
+- link_title: Derivative-free optimization - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Derivative-free_optimization
+- link_title: 'Derivative-free optimization: A review of algorithms and comparison
+    of software implementations'
+  link_url: http://thales.cheme.cmu.edu/dfo/comparison/dfo.pdf
+related_terms:
+- optimization
+- black-box-optimization
+title: Derivative-free optimization
 ---

--- a/terms/differential-evolution.md
+++ b/terms/differential-evolution.md
@@ -1,5 +1,6 @@
 ---
-title: Differential Evolution (DE)
 references:
- - "[Differential evolution - Wikipedia](https://en.wikipedia.org/wiki/Differential_evolution)"
+- link_title: Differential evolution - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Differential_evolution
+title: Differential Evolution (DE)
 ---

--- a/terms/dirichlet-multinomial-distribution.md
+++ b/terms/dirichlet-multinomial-distribution.md
@@ -1,7 +1,8 @@
 ---
-title: Dirichlet-multinomial distribution
-related_terms:
- - multinomial-distribution
 references:
- - "[Dirichlet-multinomial distribution](https://en.wikipedia.org/wiki/Dirichlet-multinomial_distribution)"
+- link_title: Dirichlet-multinomial distribution
+  link_url: https://en.wikipedia.org/wiki/Dirichlet-multinomial_distribution
+related_terms:
+- multinomial-distribution
+title: Dirichlet-multinomial distribution
 ---

--- a/terms/distributed-representation.md
+++ b/terms/distributed-representation.md
@@ -1,10 +1,13 @@
 ---
-title: Distributed representation
-related_terms:
- - word-embedding
 references:
- - "[Distributed Representation - Directory of Cognitive Science](http://www.bcp.psych.ualberta.ca/~mike/Pearl_Street/Dictionary/contents/D/distributed.html)"
- - "[Local and distributed representations - Programming Methods for Cognitive Science](http://www.indiana.edu/~gasser/Q530/Notes/representation.html)"
+- link_title: Distributed Representation - Directory of Cognitive Science
+  link_url: http://www.bcp.psych.ualberta.ca/~mike/Pearl_Street/Dictionary/contents/D/distributed.html
+- link_title: Local and distributed representations - Programming Methods for Cognitive
+    Science
+  link_url: http://www.indiana.edu/~gasser/Q530/Notes/representation.html
+related_terms:
+- word-embedding
+title: Distributed representation
 ---
 In machine learning, data with a *local representation* typically has 1 unit per element.
 A 5-word vocabulary might be defined by a 5-dimensional vector, with

--- a/terms/distributional-similarity.md
+++ b/terms/distributional-similarity.md
@@ -1,8 +1,10 @@
 ---
-title: Distributional similarity
 references:
- - "[Distributional semantics - Wikipedia](https://en.wikipedia.org/wiki/Distributional_semantics)"
- - "[word2vec - Stanford CS224N Lecture 2](https://www.youtube.com/watch?v=ERibwqs9p38)"
+- link_title: Distributional semantics - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Distributional_semantics
+- link_title: word2vec - Stanford CS224N Lecture 2
+  link_url: https://www.youtube.com/watch?v=ERibwqs9p38
+title: Distributional similarity
 ---
 Distributional similarity is the idea that the meaning of words can be understood
 from their context.

--- a/terms/domain-adaptation.md
+++ b/terms/domain-adaptation.md
@@ -1,5 +1,6 @@
 ---
-title: Domain adaptation
 references:
- - "[Domain adaptation - Wikipedia](https://en.wikipedia.org/wiki/Domain_adaptation)"
+- link_title: Domain adaptation - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Domain_adaptation
+title: Domain adaptation
 ---

--- a/terms/dropout.md
+++ b/terms/dropout.md
@@ -1,12 +1,15 @@
 ---
-title: Dropout
-related_terms:
- - regularization
- - model-averaging
 references:
- - "[Dropout (neural networks) - Wikipedia](https://en.wikipedia.org/wiki/Dropout_(neural_networks))"
- - "[How does the dropout method work in deep learning? - Quora](https://www.quora.com/How-does-the-dropout-method-work-in-deep-learning)"
- - "[Improving neural networks by preventing co-adaptation of feature detectors](https://arxiv.org/abs/1207.0580)"
+- link_title: Dropout (neural networks) - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Dropout_(neural_networks
+- link_title: How does the dropout method work in deep learning? - Quora
+  link_url: https://www.quora.com/How-does-the-dropout-method-work-in-deep-learning
+- link_title: Improving neural networks by preventing co-adaptation of feature detectors
+  link_url: https://arxiv.org/abs/1207.0580
+related_terms:
+- regularization
+- model-averaging
+title: Dropout
 ---
 Dropout is a technique for [regularizing](/terms/regularization)
 neural networks, developed by Hinton et al. and published

--- a/terms/dying-relu.md
+++ b/terms/dying-relu.md
@@ -1,10 +1,12 @@
 ---
-title: Dying ReLU
-related_terms:
- - leaky-relu
- - rectified-linear-unit-relu
 references:
- - '[What is the “dying ReLU” problem in neural networks? - Data Science StackExchange](https://datascience.stackexchange.com/questions/5706/what-is-the-dying-relu-problem-in-neural-networks)'
+- link_title: "What is the \u201Cdying ReLU\u201D problem in neural networks? - Data\
+    \ Science StackExchange"
+  link_url: https://datascience.stackexchange.com/questions/5706/what-is-the-dying-relu-problem-in-neural-networks
+related_terms:
+- leaky-relu
+- rectified-linear-unit-relu
+title: Dying ReLU
 ---
 *Dying ReLU* refers to a problem when training neural 
 networks with [rectified linear units (ReLU)][1].

--- a/terms/dynamic-k-max-pooling.md
+++ b/terms/dynamic-k-max-pooling.md
@@ -1,10 +1,11 @@
 ---
-title: Dynamic k-Max Pooling
-related_terms:
- - pooling-layer
- - convolutional-neural-network-cnn
- - max-pooling
- - k-max-pooling
 references:
- - "[A Convolutional Neural Network for Modelling Sentences](https://arxiv.org/abs/1404.2188)"
+- link_title: A Convolutional Neural Network for Modelling Sentences
+  link_url: https://arxiv.org/abs/1404.2188
+related_terms:
+- pooling-layer
+- convolutional-neural-network-cnn
+- max-pooling
+- k-max-pooling
+title: Dynamic k-Max Pooling
 ---

--- a/terms/embed-encode-attend-predict.md
+++ b/terms/embed-encode-attend-predict.md
@@ -1,12 +1,14 @@
 ---
-title: Embed, Encode, Attend, Predict
-related_terms:
- - natural-language-processing
- - recurrent-neural-network-language-model-rnnlm
- - word-embedding
- - paragraph-vector
 references:
- - "[Embed, encode, attend, predict: The new deep learning formula for state-of-the-art NLP models - explosion.ai](https://explosion.ai/blog/deep-learning-formula-nlp)"
+- link_title: 'Embed, encode, attend, predict: The new deep learning formula for state-of-the-art
+    NLP models - explosion.ai'
+  link_url: https://explosion.ai/blog/deep-learning-formula-nlp
+related_terms:
+- natural-language-processing
+- recurrent-neural-network-language-model-rnnlm
+- word-embedding
+- paragraph-vector
+title: Embed, Encode, Attend, Predict
 ---
 The phrase *Embed, Encode, Attend, Predict* refers to Matthew
 Honnibal's [conceptual framework for deep learning for natural

--- a/terms/entailment.md
+++ b/terms/entailment.md
@@ -1,12 +1,16 @@
 ---
-title: Entailment
-related_terms:
- - natural-language-processing
 references:
- - "[Entailment (linguistics) - Wikipedia](https://en.wikipedia.org/wiki/Entailment_(linguistics))"
- - "[Textual entailment - Wikipedia](https://en.wikipedia.org/wiki/Textual_entailment)"
- - "[A machine learning approach to textual entailment recognition](http://disi.unitn.it/moschitti/articles/NLE09.pdf)"
- - "[Recognizing Textual Entailment](http://l2r.cs.uiuc.edu/~danr/Teaching/CS546-12/TeChapter.pdf)"
+- link_title: Entailment (linguistics) - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Entailment_(linguistics
+- link_title: Textual entailment - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Textual_entailment
+- link_title: A machine learning approach to textual entailment recognition
+  link_url: http://disi.unitn.it/moschitti/articles/NLE09.pdf
+- link_title: Recognizing Textual Entailment
+  link_url: http://l2r.cs.uiuc.edu/~danr/Teaching/CS546-12/TeChapter.pdf
+related_terms:
+- natural-language-processing
+title: Entailment
 ---
 The word *entailment* has many meanings. Please review Wikipedia's [disambiguation page for "entail"][1]
 for definitions that do not refer to *textual entailment*.

--- a/terms/error-correcting-tournaments.md
+++ b/terms/error-correcting-tournaments.md
@@ -1,5 +1,6 @@
 ---
-title: Error-Correcting Tournaments
 references:
- - "[Error-Correcting Tournaments](https://arxiv.org/abs/0902.3176)"
+- link_title: Error-Correcting Tournaments
+  link_url: https://arxiv.org/abs/0902.3176
+title: Error-Correcting Tournaments
 ---

--- a/terms/expectation-maximization-em-algorithm.md
+++ b/terms/expectation-maximization-em-algorithm.md
@@ -1,9 +1,10 @@
 ---
-title: Expectation-maximization (EM) algorithm
-related_terms:
- - maximum-a-posteriori-map-estimation
- - maximum-likelihood-estimation-mle
- - expectation
 references:
- - "[Expectation-maximization algorithm](https://en.wikipedia.org/wiki/Expectation%E2%80%93maximization_algorithm)"
+- link_title: Expectation-maximization algorithm
+  link_url: https://en.wikipedia.org/wiki/Expectation%E2%80%93maximization_algorithm
+related_terms:
+- maximum-a-posteriori-map-estimation
+- maximum-likelihood-estimation-mle
+- expectation
+title: Expectation-maximization (EM) algorithm
 ---

--- a/terms/exponential-linear-unit-elu.md
+++ b/terms/exponential-linear-unit-elu.md
@@ -1,9 +1,12 @@
 ---
-title: Exponential Linear Unit (ELU)
-related_terms:
- - rectified-linear-unit-relu
- - activation-function
 references:
- - "[Fast and Accurate Deep Network Learning by Exponential Linear Units (ELUs)](https://arxiv.org/abs/1511.07289)"
- - "[Deep Residual Networks with Exponential Linear Unit](https://arxiv.org/abs/1604.04112)"
+- link_title: Fast and Accurate Deep Network Learning by Exponential Linear Units
+    (ELUs)
+  link_url: https://arxiv.org/abs/1511.07289
+- link_title: Deep Residual Networks with Exponential Linear Unit
+  link_url: https://arxiv.org/abs/1604.04112
+related_terms:
+- rectified-linear-unit-relu
+- activation-function
+title: Exponential Linear Unit (ELU)
 ---

--- a/terms/extractive-sentence-summarization.md
+++ b/terms/extractive-sentence-summarization.md
@@ -1,11 +1,11 @@
 ---
-title: Extractive sentence summarization
-related_terms:
- - abstractive-sentence-summarization
- - textrank
 references:
- - "[Extractive Summarization Using Supervised and Semi-supervised
-Learning](http://anthology.aclweb.org/C/C08/C08-1124.pdf)"
+- link_title: Extractive Summarization Using Supervised and Semi-supervised Learning
+  link_url: http://anthology.aclweb.org/C/C08/C08-1124.pdf
+related_terms:
+- abstractive-sentence-summarization
+- textrank
+title: Extractive sentence summarization
 ---
 Extractive sentence summarization refers to programmatically
 creating a shorter version of a document by extracting

--- a/terms/facet.md
+++ b/terms/facet.md
@@ -1,8 +1,10 @@
 ---
-title: Facet
 references:
- - "[Facets (ggplot2)](http://www.cookbook-r.com/Graphs/Facets_(ggplot2)/)"
- - "[Plotting multiple groups with facets in ggplot2](https://www3.nd.edu/~steve/computing_with_data/13_Facets/facets.html)"
+- link_title: Facets (ggplot2)
+  link_url: http://www.cookbook-r.com/Graphs/Facets_(ggplot2
+- link_title: Plotting multiple groups with facets in ggplot2
+  link_url: https://www3.nd.edu/~steve/computing_with_data/13_Facets/facets.html
+title: Facet
 ---
 In statistical plotting, a facet is a type of plot. Data
 is split into subsets and the subsets are plotted

--- a/terms/fast-fourier-transform-fft.md
+++ b/terms/fast-fourier-transform-fft.md
@@ -1,5 +1,6 @@
 ---
-title: Fast Fourier transform (FFT)
 references:
- - "[Fast Fourier transform - Wikipedia](https://en.wikipedia.org/wiki/Fast_Fourier_transform)"
+- link_title: Fast Fourier transform - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Fast_Fourier_transform
+title: Fast Fourier transform (FFT)
 ---

--- a/terms/filter-convolution.md
+++ b/terms/filter-convolution.md
@@ -1,7 +1,8 @@
 ---
-title: Filter (convolution)
 references:
- - "[Kernel (image processig) - Wikipedia](https://en.wikipedia.org/wiki/Kernel_(image_processing))"
+- link_title: Kernel (image processig) - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Kernel_(image_processing
+title: Filter (convolution)
 ---
 A *filter* (also known as a *kernel*) is a small matrix
 used in convolution operations.

--- a/terms/finite-state-transducer-fst.md
+++ b/terms/finite-state-transducer-fst.md
@@ -1,5 +1,6 @@
 ---
-title: Finite-state transducer (FST)
 references:
- - "[Finite state transducer - Wikipedia](https://en.wikipedia.org/wiki/Finite-state_transducer)"
+- link_title: Finite state transducer - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Finite-state_transducer
+title: Finite-state transducer (FST)
 ---

--- a/terms/gap-statistic.md
+++ b/terms/gap-statistic.md
@@ -1,7 +1,8 @@
 ---
-title: Gap statistic
-related_terms:
- - k-means-clustering
 references:
- - "[Estimating the number of clusters in a data set via the gap statistic](http://statweb.stanford.edu/~gwalther/gap.pdf)"
+- link_title: Estimating the number of clusters in a data set via the gap statistic
+  link_url: http://statweb.stanford.edu/~gwalther/gap.pdf
+related_terms:
+- k-means-clustering
+title: Gap statistic
 ---

--- a/terms/gaussian-mixture-model-gmm.md
+++ b/terms/gaussian-mixture-model-gmm.md
@@ -1,5 +1,6 @@
 ---
-title: Gaussian mixture model (GMM)
 references:
- - "[Mixture model - Wikipedia](https://en.wikipedia.org/wiki/Mixture_model)"
+- link_title: Mixture model - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Mixture_model
+title: Gaussian mixture model (GMM)
 ---

--- a/terms/generalized-additive-model-gam.md
+++ b/terms/generalized-additive-model-gam.md
@@ -1,7 +1,8 @@
 ---
-title: Generalized additive model (GAM)
-related_terms:
- - additive-model
 references:
- - "[Generalized additive model - Wikipedia](https://en.wikipedia.org/wiki/Generalized_additive_model)"
+- link_title: Generalized additive model - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Generalized_additive_model
+related_terms:
+- additive-model
+title: Generalized additive model (GAM)
 ---

--- a/terms/generative-adversarial-network-gan.md
+++ b/terms/generative-adversarial-network-gan.md
@@ -1,7 +1,10 @@
 ---
-title: Generative Adversarial Network (GAN)
 references:
- - "[Generative adversarial networks - Wikipedia](https://en.wikipedia.org/wiki/Generative_adversarial_networks)"
- - "[Generative adversarial networks](https://arxiv.org/abs/1406.2661)"
- - "[NIPS 2016 tutorial: Generative Adversarial Networks](https://arxiv.org/abs/1701.00160)"
+- link_title: Generative adversarial networks - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Generative_adversarial_networks
+- link_title: Generative adversarial networks
+  link_url: https://arxiv.org/abs/1406.2661
+- link_title: 'NIPS 2016 tutorial: Generative Adversarial Networks'
+  link_url: https://arxiv.org/abs/1701.00160
+title: Generative Adversarial Network (GAN)
 ---

--- a/terms/global-average-pooling-gap.md
+++ b/terms/global-average-pooling-gap.md
@@ -1,7 +1,8 @@
 ---
-title: Global Average Pooling (GAP)
-related_terms:
- - pooling-layer
 references:
- - "[Learning Deep Features for Discriminative Localization](http://cnnlocalization.csail.mit.edu/)"
+- link_title: Learning Deep Features for Discriminative Localization
+  link_url: http://cnnlocalization.csail.mit.edu/
+related_terms:
+- pooling-layer
+title: Global Average Pooling (GAP)
 ---

--- a/terms/glove-word-embeddings.md
+++ b/terms/glove-word-embeddings.md
@@ -1,11 +1,13 @@
 ---
-title: GloVe (Global Vectors) embeddings
-related_terms:
- - word2vec
- - word-embedding
 references:
- - "[GloVe: Global Vectors for Word Representation - Stanford NLP Group](https://nlp.stanford.edu/pubs/glove.pdf)"
- - "[GloVe - Stanford NLP project page](https://nlp.stanford.edu/projects/glove/)"
+- link_title: 'GloVe: Global Vectors for Word Representation - Stanford NLP Group'
+  link_url: https://nlp.stanford.edu/pubs/glove.pdf
+- link_title: GloVe - Stanford NLP project page
+  link_url: https://nlp.stanford.edu/projects/glove/
+related_terms:
+- word2vec
+- word-embedding
+title: GloVe (Global Vectors) embeddings
 ---
 GloVe, or Global Vectors, refers to a word embedding algorithm
 from the Stanford NLP group.

--- a/terms/gradient-clipping.md
+++ b/terms/gradient-clipping.md
@@ -1,9 +1,11 @@
 ---
-title: Gradient Clipping
-related_terms:
- - recurrent-neural-network
- - long-short-term-memory-lstm
 references:
- - "[Gradient Clipping - Tensorflow Python Documentation](https://www.tensorflow.org/versions/r0.12/api_docs/python/train/gradient_clipping)"
- - "[On the difficulty of training Recurrent Neural Networks](https://arxiv.org/abs/1211.5063)"
+- link_title: Gradient Clipping - Tensorflow Python Documentation
+  link_url: https://www.tensorflow.org/versions/r0.12/api_docs/python/train/gradient_clipping
+- link_title: On the difficulty of training Recurrent Neural Networks
+  link_url: https://arxiv.org/abs/1211.5063
+related_terms:
+- recurrent-neural-network
+- long-short-term-memory-lstm
+title: Gradient Clipping
 ---

--- a/terms/gram-matrix.md
+++ b/terms/gram-matrix.md
@@ -1,9 +1,12 @@
 ---
-title: Gram matrix
 references:
- - "[Gramian matrix - Wikipedia](https://en.wikipedia.org/wiki/Gramian_matrix)"
- - "[Gram Matrix - Wolfram Mathworld](http://mathworld.wolfram.com/GramMatrix.html)"
- - "[Gram matrix - Encyclopedia of Mathematics](https://www.encyclopediaofmath.org/index.php/Gram_matrix)"
+- link_title: Gramian matrix - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Gramian_matrix
+- link_title: Gram Matrix - Wolfram Mathworld
+  link_url: http://mathworld.wolfram.com/GramMatrix.html
+- link_title: Gram matrix - Encyclopedia of Mathematics
+  link_url: https://www.encyclopediaofmath.org/index.php/Gram_matrix
+title: Gram matrix
 ---
 [Wolfram Mathworld defines Gram matrix as][1]:
 

--- a/terms/graph-neural-network.md
+++ b/terms/graph-neural-network.md
@@ -1,7 +1,8 @@
 ---
-title: Graph Neural Network
-related_terms:
- - recursive-neural-network
 references:
- - "[The Graph Neural Network Model](http://repository.hkbu.edu.hk/cgi/viewcontent.cgi?article=1000&context=vprd_ja)"
+- link_title: The Graph Neural Network Model
+  link_url: http://repository.hkbu.edu.hk/cgi/viewcontent.cgi?article=1000&context=vprd_ja
+related_terms:
+- recursive-neural-network
+title: Graph Neural Network
 ---

--- a/terms/harmonic-precision-recall-mean-f1-score.md
+++ b/terms/harmonic-precision-recall-mean-f1-score.md
@@ -1,8 +1,10 @@
 ---
-title: "Harmonic Precision-Recall Mean (F1 Score)"
 references:
- - "[Precision and recall - Wikipedia](https://en.wikipedia.org/wiki/Precision_and_recall)"
- - "[F1 score](https://en.wikipedia.org/wiki/F1_score)"
+- link_title: Precision and recall - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Precision_and_recall
+- link_title: F1 score
+  link_url: https://en.wikipedia.org/wiki/F1_score
+title: Harmonic Precision-Recall Mean (F1 Score)
 ---
 The $F_1$ score is a classification accuracy metric
 that combines precision and recall. It is designed

--- a/terms/he-initialization.md
+++ b/terms/he-initialization.md
@@ -1,12 +1,13 @@
 ---
-title: He initialization
-related_terms:
- - symmetry-breaking
- - random-initialization
 references:
- - "[Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification](https://arxiv.org/abs/1502.01852)"
+- link_title: 'Delving Deep into Rectifiers: Surpassing Human-Level Performance on
+    ImageNet Classification'
+  link_url: https://arxiv.org/abs/1502.01852
+related_terms:
+- symmetry-breaking
+- random-initialization
+title: He initialization
 ---
-
 The term *He initialization* refers to the first author in the paper
 "[Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification](https://arxiv.org/abs/1502.01852)".
 
@@ -14,4 +15,3 @@ He initialization initializes the bias vectors of a neural network
 to $0$ and the weights to random numbers drawn from a Gaussian
 distribution where the mean is $0$ and the variance is
 $\sqrt(2/n_l)$ where $n_l$ is the dimension of the previous layer.
-

--- a/terms/hessian-free-optimization.md
+++ b/terms/hessian-free-optimization.md
@@ -1,7 +1,11 @@
 ---
-title: Hessian-free optimization
 references:
- - "[Hessian Free Optimization - Andrew Gibiansky](http://andrew.gibiansky.com/blog/machine-learning/hessian-free-optimization/)"
- - "[Deep learning via Hessian-free optimization](http://www.cs.toronto.edu/~jmartens/docs/Deep_HessianFree.pdf)"
- - "[Hessian-free Optimization for Learning Deep Multidimensional Recurrent Neural Networks](https://arxiv.org/abs/1509.03475)"
+- link_title: Hessian Free Optimization - Andrew Gibiansky
+  link_url: http://andrew.gibiansky.com/blog/machine-learning/hessian-free-optimization/
+- link_title: Deep learning via Hessian-free optimization
+  link_url: http://www.cs.toronto.edu/~jmartens/docs/Deep_HessianFree.pdf
+- link_title: Hessian-free Optimization for Learning Deep Multidimensional Recurrent
+    Neural Networks
+  link_url: https://arxiv.org/abs/1509.03475
+title: Hessian-free optimization
 ---

--- a/terms/hopfield-network-hn.md
+++ b/terms/hopfield-network-hn.md
@@ -1,13 +1,14 @@
 ---
-title: Hopfield Network
-related_terms:
- - recurrent-neural-network
- - neural-network
 references:
- - "[Hopfield Network - Wikipedia](https://en.wikipedia.org/wiki/Hopfield_network)"
- - "[Hopfield Network](https://bi.snu.ac.kr/Courses/g-ai09-2/hopfield82.pdf)"
+- link_title: Hopfield Network - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Hopfield_network
+- link_title: Hopfield Network
+  link_url: https://bi.snu.ac.kr/Courses/g-ai09-2/hopfield82.pdf
+related_terms:
+- recurrent-neural-network
+- neural-network
+title: Hopfield Network
 ---
-
 A Hopfield network (HN) is a type of [recurrent neural network][1](RNN). The HNs have only one layer, with each neuron connected to every other neuron: All neurons act as input and output.  The model of the network consists of a set of neurons and corresponding set of unit delays, forming a multiple loop feedback system. The output of a neuron is, via a unit delay element, sent to all of the others neurons in the HN, except itself.
 
 Some important properties of HNs are that all neurons have binary outputs (either 0, 1 or -1, 1), it isn't allowed a connection from a neuron to itself, the neurons are updated at random order (asynchronously), and the weights between the neurons are symmetric. This last property guarantees that the energy function decreases while following the activation function rules, and HNs are guaranteed to converge to a local minimum.

--- a/terms/hypergraph.md
+++ b/terms/hypergraph.md
@@ -1,11 +1,14 @@
 ---
-title: Hypergraph
-related_terms:
- - graph
 references:
- - "[Hypergraph - Wikipedia](https://en.wikipedia.org/wiki/Hypergraph)"
- - "[Learning with Hypergraphs: Clustering, Classification, Embedding](https://papers.nips.cc/paper/3128-learning-with-hypergraphs-clustering-classification-and-embedding.pdf)"
- - "[What are the applications of hypergraphs? - Math Overflow](https://mathoverflow.net/questions/13750/what-are-the-applications-of-hypergraphs)"
+- link_title: Hypergraph - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Hypergraph
+- link_title: 'Learning with Hypergraphs: Clustering, Classification, Embedding'
+  link_url: https://papers.nips.cc/paper/3128-learning-with-hypergraphs-clustering-classification-and-embedding.pdf
+- link_title: What are the applications of hypergraphs? - Math Overflow
+  link_url: https://mathoverflow.net/questions/13750/what-are-the-applications-of-hypergraphs
+related_terms:
+- graph
+title: Hypergraph
 ---
 A hypergraph is a generalization of the [graph][1]. A graph has edges that connect
 pairs of vertices, but a hypergraph has hyperedges that can connect any number

--- a/terms/hypernetwork.md
+++ b/terms/hypernetwork.md
@@ -1,5 +1,6 @@
 ---
-title: Hypernetwork
 references:
- - "[Hypernetworks](https://arxiv.org/abs/1609.09106)"
+- link_title: Hypernetworks
+  link_url: https://arxiv.org/abs/1609.09106
+title: Hypernetwork
 ---

--- a/terms/inception-neural-network.md
+++ b/terms/inception-neural-network.md
@@ -1,19 +1,27 @@
 ---
-title: Inception
-related_terms:
- - convolutional-neural-network-cnn
- - alexnet
- - lenet
- - vggnet
- - googlenet-neural-network
 references:
- - "[google/inception - Github](https://github.com/google/inception)"
- - "[Going Deeper With Convolutions](https://arxiv.org/abs/1409.4842)"
- - "[Inceptionism: Going Deeper into Neural Networks](https://research.googleblog.com/2015/06/inceptionism-going-deeper-into-neural.html)"
- - "[How does the Inception module work in GoogLeNet deep architecture?](https://www.quora.com/How-does-the-Inception-module-work-in-GoogLeNet-deep-architecture)"
- - "[Inception in Tensorflow - Github](https://github.com/tensorflow/models/tree/master/inception)"
- - "[Rethinking the Inception Architecture for Computer Vision](https://arxiv.org/abs/1512.00567)"
- - "[Inception-v4, Inception-ResNet and the Impact of Residual Connections on Learning](https://arxiv.org/abs/1602.07261)"
+- link_title: google/inception - Github
+  link_url: https://github.com/google/inception
+- link_title: Going Deeper With Convolutions
+  link_url: https://arxiv.org/abs/1409.4842
+- link_title: 'Inceptionism: Going Deeper into Neural Networks'
+  link_url: https://research.googleblog.com/2015/06/inceptionism-going-deeper-into-neural.html
+- link_title: How does the Inception module work in GoogLeNet deep architecture?
+  link_url: https://www.quora.com/How-does-the-Inception-module-work-in-GoogLeNet-deep-architecture
+- link_title: Inception in Tensorflow - Github
+  link_url: https://github.com/tensorflow/models/tree/master/inception
+- link_title: Rethinking the Inception Architecture for Computer Vision
+  link_url: https://arxiv.org/abs/1512.00567
+- link_title: Inception-v4, Inception-ResNet and the Impact of Residual Connections
+    on Learning
+  link_url: https://arxiv.org/abs/1602.07261
+related_terms:
+- convolutional-neural-network-cnn
+- alexnet
+- lenet
+- vggnet
+- googlenet-neural-network
+title: Inception
 ---
 *Inception* refers to a particular neural network model in the
 CVPR 2015 paper titled [Going Deeper With Convolutions](https://arxiv.org/abs/1409.4842).

--- a/terms/indian-buffet-process.md
+++ b/terms/indian-buffet-process.md
@@ -1,7 +1,8 @@
 ---
-title: Indian Buffet Process
-related_terms:
- - chinese-restaurant-process
 references:
- - "[Indian buffet process - Wikipedia](https://en.wikipedia.org/wiki/Chinese_restaurant_process#The_Indian_buffet_process)"
+- link_title: Indian buffet process - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Chinese_restaurant_process#The_Indian_buffet_process
+related_terms:
+- chinese-restaurant-process
+title: Indian Buffet Process
 ---

--- a/terms/internal-covariate-shift.md
+++ b/terms/internal-covariate-shift.md
@@ -1,11 +1,13 @@
 ---
-title: Internal covariate shift
-related_terms:
- - neural-network
- - covariate-shift
- - batch-normalization
 references:
- - "[Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift](https://arxiv.org/abs/1502.03167)"
+- link_title: 'Batch Normalization: Accelerating Deep Network Training by Reducing
+    Internal Covariate Shift'
+  link_url: https://arxiv.org/abs/1502.03167
+related_terms:
+- neural-network
+- covariate-shift
+- batch-normalization
+title: Internal covariate shift
 ---
 The term *interal covariate shift* comes from the paper
 [Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift][1].

--- a/terms/inverted-dropout.md
+++ b/terms/inverted-dropout.md
@@ -1,11 +1,12 @@
 ---
-title: Inverted dropout
-related_terms:
- - regularization
- - model-averaging
- - dropout
 references:
- - "[Analysis of Dropout](https://pgaleone.eu/deep-learning/regularization/2017/01/10/anaysis-of-dropout/)"
+- link_title: Analysis of Dropout
+  link_url: https://pgaleone.eu/deep-learning/regularization/2017/01/10/anaysis-of-dropout/
+related_terms:
+- regularization
+- model-averaging
+- dropout
+title: Inverted dropout
 ---
 Inverted dropout is a variant of the original [dropout](/terms/dropout)
 technique developed by Hinton et al.

--- a/terms/k-max-pooling.md
+++ b/terms/k-max-pooling.md
@@ -1,10 +1,11 @@
 ---
-title: k-Max Pooling
-related_terms:
- - pooling-layer
- - convolutional-neural-network-cnn
- - dynamic-k-max-pooling
- - max-pooling
 references:
- - "[A Convolutional Neural Network for Modelling Sentences](https://arxiv.org/abs/1404.2188)"
+- link_title: A Convolutional Neural Network for Modelling Sentences
+  link_url: https://arxiv.org/abs/1404.2188
+related_terms:
+- pooling-layer
+- convolutional-neural-network-cnn
+- dynamic-k-max-pooling
+- max-pooling
+title: k-Max Pooling
 ---

--- a/terms/latent-dirichlet-allocation-differential-evolution-ldade.md
+++ b/terms/latent-dirichlet-allocation-differential-evolution-ldade.md
@@ -1,12 +1,14 @@
 ---
-title: Latent Dirichlet Allocation Differential Evolution (LDADE)
-related_terms:
- - latent-dirichlet-allocation-lda
- - differential-evolution
- - clustering-stability
- - search-based-software-engineering-sbse
 references:
- - "[What is Wrong with Topic Modeling? (and How to Fix it Using Search-based Software Engineering)](https://arxiv.org/abs/1608.08176)"
+- link_title: What is Wrong with Topic Modeling? (and How to Fix it Using Search-based
+    Software Engineering)
+  link_url: https://arxiv.org/abs/1608.08176
+related_terms:
+- latent-dirichlet-allocation-lda
+- differential-evolution
+- clustering-stability
+- search-based-software-engineering-sbse
+title: Latent Dirichlet Allocation Differential Evolution (LDADE)
 ---
 LDADE is a tool proposed by Agrawal et al. in a paper
 titled [What is Wrong with Topic Modeling? (and How to Fix it Using Search-based Software Engineering)](https://arxiv.org/abs/1608.08176).

--- a/terms/latent-semantic-indexing-lsi.md
+++ b/terms/latent-semantic-indexing-lsi.md
@@ -1,10 +1,13 @@
 ---
-title: Latent Semantic Indexing (LSI)
-related_terms:
- - latent-dirichlet-allocation-lda
- - singular-value-decomposition-svd
 references:
- - "[Latent semantic indexing - Wikipedia](https://en.wikipedia.org/wiki/Latent_semantic_analysis#Latent_semantic_indexing)"
- - "[What is latent semantic indexing? - Search Engine Journal](https://www.searchenginejournal.com/what-is-latent-semantic-indexing-seo-defined/21642/)"
- - "[Latent Semantic Indexing - Introduction to Information Retrieval](https://nlp.stanford.edu/IR-book/html/htmledition/latent-semantic-indexing-1.html)"
+- link_title: Latent semantic indexing - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Latent_semantic_analysis#Latent_semantic_indexing
+- link_title: What is latent semantic indexing? - Search Engine Journal
+  link_url: https://www.searchenginejournal.com/what-is-latent-semantic-indexing-seo-defined/21642/
+- link_title: Latent Semantic Indexing - Introduction to Information Retrieval
+  link_url: https://nlp.stanford.edu/IR-book/html/htmledition/latent-semantic-indexing-1.html
+related_terms:
+- latent-dirichlet-allocation-lda
+- singular-value-decomposition-svd
+title: Latent Semantic Indexing (LSI)
 ---

--- a/terms/learning-rate-decay.md
+++ b/terms/learning-rate-decay.md
@@ -1,9 +1,11 @@
 ---
-title: Learning rate decay
-related_terms:
- - learning-rate
- - stochastic-gradient-descent-sgd
 references:
- - "[Decaying the learning rate - TensorFlow Documentation](https://www.tensorflow.org/versions/r0.11/api_docs/python/train/decaying_the_learning_rate)"
- - "[Annealing the learning rate - Stanford CS231n](http://cs231n.github.io/neural-networks-3/#anneal)"
+- link_title: Decaying the learning rate - TensorFlow Documentation
+  link_url: https://www.tensorflow.org/versions/r0.11/api_docs/python/train/decaying_the_learning_rate
+- link_title: Annealing the learning rate - Stanford CS231n
+  link_url: http://cs231n.github.io/neural-networks-3/#anneal
+related_terms:
+- learning-rate
+- stochastic-gradient-descent-sgd
+title: Learning rate decay
 ---

--- a/terms/learning-to-rank-ltr.md
+++ b/terms/learning-to-rank-ltr.md
@@ -1,10 +1,12 @@
 ---
-title: Learning To Rank (LTR)
-related_terms:
- - collaborative-filtering
 references:
- - "[Learning to rank - Wikipedia](https://en.wikipedia.org/wiki/Learning_to_rank)"
- - "[Learning To Rank - Apache Solr Documentation](https://cwiki.apache.org/confluence/display/solr/Learning+To+Rank)"
+- link_title: Learning to rank - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Learning_to_rank
+- link_title: Learning To Rank - Apache Solr Documentation
+  link_url: https://cwiki.apache.org/confluence/display/solr/Learning+To+Rank
+related_terms:
+- collaborative-filtering
+title: Learning To Rank (LTR)
 ---
 Learning-to-rank is the application of machine learning
 to ranking search results, recommendations, or similar

--- a/terms/lenet.md
+++ b/terms/lenet.md
@@ -1,10 +1,12 @@
 ---
-title: LeNet
-related_terms:
- - convolutional-neural-network-cnn
 references:
- - "[Case Studies - Stanford CS231n Convolutional Neural Networks](http://cs231n.github.io/convolutional-networks/#case)"
- - "[Gradient-Based Learning Applied to Document Recognition](http://yann.lecun.com/exdb/publis/pdf/lecun-98.pdf)"
+- link_title: Case Studies - Stanford CS231n Convolutional Neural Networks
+  link_url: http://cs231n.github.io/convolutional-networks/#case
+- link_title: Gradient-Based Learning Applied to Document Recognition
+  link_url: http://yann.lecun.com/exdb/publis/pdf/lecun-98.pdf
+related_terms:
+- convolutional-neural-network-cnn
+title: LeNet
 ---
 LeNet was an early convolutional neural network proposed
 by Lecun et al in the paper

--- a/terms/long-short-term-memory-lstm.md
+++ b/terms/long-short-term-memory-lstm.md
@@ -1,14 +1,14 @@
 ---
-title: Long Short-Term Memory (LSTM)
-related_terms:
- - recurrent-neural-network
- - backpropagation
-
 references:
- - "[Long Short-Term Memory - Wikipedia](https://en.wikipedia.org/wiki/Long_short-term_memory)"
- - "[LONG SHORT-TERM MEMORY](http://www.bioinf.jku.at/publications/older/2604.pdf)"
+- link_title: Long Short-Term Memory - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Long_short-term_memory
+- link_title: LONG SHORT-TERM MEMORY
+  link_url: http://www.bioinf.jku.at/publications/older/2604.pdf
+related_terms:
+- recurrent-neural-network
+- backpropagation
+title: Long Short-Term Memory (LSTM)
 ---
-
 Long short term memory (LSTM) networks try to reduce the vanishing and exploding gradient problem during the backpropagation in recurrent neural networks. LSTM are in general, a RNN where each neuron has a memory cell and three gates: input, output and forget. The purpose of the memory cell is to retain information previously used by the RNN, or forget if needed. LSTMs are explicitly designed to avoid the long-term dependency problem in RNNs, and have been shown to be able to learn complex sequences better than simple RNNs.
 
 The structure of a memory cell is: an input gate, that determines how much of information from the previous layer gets stored in the cell; the output gate, that determines how of the next layer gets to know about the state of the current cell; and the forget gate, which determines what to forget about the current state of the memory cell.

--- a/terms/maxout-activation-function.md
+++ b/terms/maxout-activation-function.md
@@ -1,8 +1,9 @@
 ---
-title: Maxout
-related_terms:
- - activation-function
- - dropout
 references:
- - "[Maxout networks](https://arxiv.org/abs/1302.4389)"
+- link_title: Maxout networks
+  link_url: https://arxiv.org/abs/1302.4389
+related_terms:
+- activation-function
+- dropout
+title: Maxout
 ---

--- a/terms/mean-reciprocal-rank-mrr.md
+++ b/terms/mean-reciprocal-rank-mrr.md
@@ -1,10 +1,11 @@
 ---
-title: Mean Reciprocal Rank (MRR)
 references:
- - "[Chapter 28: Question Answering - Speech and Language Processing](https://web.stanford.edu/~jurafsky/slp3/28.pdf)"
- - "[Mean reciprocal rank - Wikipedia](https://en.wikipedia.org/wiki/Mean_reciprocal_rank)"
+- link_title: 'Chapter 28: Question Answering - Speech and Language Processing'
+  link_url: https://web.stanford.edu/~jurafsky/slp3/28.pdf
+- link_title: Mean reciprocal rank - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Mean_reciprocal_rank
+title: Mean Reciprocal Rank (MRR)
 ---
-
 $\newcommand{\Correctrank}{\mathrm{rank}}$
 
 Mean Reciprocal Rank is a measure to evaluate systems that return
@@ -20,4 +21,3 @@ For multiple queries $Q$, the Mean Reciprocal Rank is the mean
 of the $Q$ reciprocal ranks.
 
 $$\mathrm{MRR} = \frac 1 Q \sum_{i=1}^{Q} \frac 1 {\Correctrank_i}$$
-

--- a/terms/mention-pair-coreference-model.md
+++ b/terms/mention-pair-coreference-model.md
@@ -1,8 +1,9 @@
 ---
-title: Mention-pair coreference model
-related_terms:
- - coreference-resolution
- - mention-ranking-coreference-model
 references:
- - "[Entity-Centric Coreference Resolution with Model Stacking](https://nlp.stanford.edu/pubs/clark-manning-acl15-entity.pdf)"
+- link_title: Entity-Centric Coreference Resolution with Model Stacking
+  link_url: https://nlp.stanford.edu/pubs/clark-manning-acl15-entity.pdf
+related_terms:
+- coreference-resolution
+- mention-ranking-coreference-model
+title: Mention-pair coreference model
 ---

--- a/terms/mention-ranking-coreference-model.md
+++ b/terms/mention-ranking-coreference-model.md
@@ -1,7 +1,8 @@
 ---
-title: Mention-ranking coreference model
-related_terms:
- - coreference-resolution
 references:
- - "[Deep Reinforcement Learning for Mention-Ranking Coreference Models](https://arxiv.org/pdf/1609.08667.pdf)"
+- link_title: Deep Reinforcement Learning for Mention-Ranking Coreference Models
+  link_url: https://arxiv.org/pdf/1609.08667.pdf
+related_terms:
+- coreference-resolution
+title: Mention-ranking coreference model
 ---

--- a/terms/meta-learning.md
+++ b/terms/meta-learning.md
@@ -1,5 +1,6 @@
 ---
-title: Meta learning
 references:
- - "[Meta learning (computer science) - Wikipedia](https://en.wikipedia.org/wiki/Meta_learning_(computer_science))"
+- link_title: Meta learning (computer science) - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Meta_learning_(computer_science
+title: Meta learning
 ---

--- a/terms/meteor-machine-translation.md
+++ b/terms/meteor-machine-translation.md
@@ -1,9 +1,10 @@
 ---
-title: METEOR
-related_terms:
- - bilingual-evaluation-understudy-bleu
 references:
- - "[METEOR - Automatic Machine Translation Evaluation System](http://www.cs.cmu.edu/~alavie/METEOR/)"
+- link_title: METEOR - Automatic Machine Translation Evaluation System
+  link_url: http://www.cs.cmu.edu/~alavie/METEOR/
+related_terms:
+- bilingual-evaluation-understudy-bleu
+title: METEOR
 ---
 METEOR is an automatic evaluation metric for machine translation,
 designed to mitigate perceived weaknesses in

--- a/terms/minimum-description-length-mdl-principle.md
+++ b/terms/minimum-description-length-mdl-principle.md
@@ -1,5 +1,6 @@
 ---
-title: Minimum description length (MDL) principle
 references:
- - "[Minimum description length - Wikipedia](https://en.wikipedia.org/wiki/Minimum_description_length)"
+- link_title: Minimum description length - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Minimum_description_length
+title: Minimum description length (MDL) principle
 ---

--- a/terms/model-parallelism.md
+++ b/terms/model-parallelism.md
@@ -1,10 +1,13 @@
 ---
-title: Model parallelism
-related_terms:
- - data-parallelism
 references:
- - "[What is the difference between model parallelism and data parallelism? - Quora](https://www.quora.com/What-is-the-difference-between-model-parallelism-and-data-parallelism)"
- - "[Training with Multiple GPUs Using Model Parallelism - MXNet documentation](http://mxnet.io/how_to/model_parallel_lstm.html)"
+- link_title: What is the difference between model parallelism and data parallelism?
+    - Quora
+  link_url: https://www.quora.com/What-is-the-difference-between-model-parallelism-and-data-parallelism
+- link_title: Training with Multiple GPUs Using Model Parallelism - MXNet documentation
+  link_url: http://mxnet.io/how_to/model_parallel_lstm.html
+related_terms:
+- data-parallelism
+title: Model parallelism
 ---
 Model parallelism is where multiple computing nodes evaluate
 the same model with the same data, but using different

--- a/terms/momentum-optimization.md
+++ b/terms/momentum-optimization.md
@@ -1,12 +1,12 @@
 ---
-title: Momentum
-related_terms:
- - stochastic-optimization
- - stochastic-gradient-descent-sgd
 references:
- - "[Why Momentum Really Works - Distill](http://distill.pub/2017/momentum/)"
+- link_title: Why Momentum Really Works - Distill
+  link_url: http://distill.pub/2017/momentum/
+related_terms:
+- stochastic-optimization
+- stochastic-gradient-descent-sgd
+title: Momentum
 ---
-
 Momentum is commonly understood as a variation of [stochastic gradient descent][1],
 but with one important difference: stochastic gradient descent can
 unnecessarily oscillate, and doesn't accelerate based on the shape of the

--- a/terms/multidimensional-recurrent-neural-network-mdrnn.md
+++ b/terms/multidimensional-recurrent-neural-network-mdrnn.md
@@ -1,8 +1,11 @@
 ---
-title: Multidimensional recurrent neural network (MDRNN)
-related_terms:
- - recurrent-neural-network
 references:
- - "[Hessian-free Optimization for Learning Deep Multidimensional Recurrent Neural Networks](https://arxiv.org/abs/1509.03475)"
- - "[Multi-Dimensional Recurrent Neural Networks](https://arxiv.org/abs/0705.2011)"
+- link_title: Hessian-free Optimization for Learning Deep Multidimensional Recurrent
+    Neural Networks
+  link_url: https://arxiv.org/abs/1509.03475
+- link_title: Multi-Dimensional Recurrent Neural Networks
+  link_url: https://arxiv.org/abs/0705.2011
+related_terms:
+- recurrent-neural-network
+title: Multidimensional recurrent neural network (MDRNN)
 ---

--- a/terms/multinomial-mixture-model-mmm.md
+++ b/terms/multinomial-mixture-model-mmm.md
@@ -1,11 +1,13 @@
 ---
-title: Multinomial mixture model
-related_terms:
- - gaussian-mixture-model-gmm
- - multinomial-distribution
 references:
- - "[Multinomial distribution - Wikipedia](https://en.wikipedia.org/wiki/Multinomial_distribution)"
- - "[Mixture model - Wikipedia](https://en.wikipedia.org/wiki/Mixture_model)"
+- link_title: Multinomial distribution - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Multinomial_distribution
+- link_title: Mixture model - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Mixture_model
+related_terms:
+- gaussian-mixture-model-gmm
+- multinomial-distribution
+title: Multinomial mixture model
 ---
 A multinomial mixture model is a mixture of multinomial distributions.
 

--- a/terms/multiple-crops-at-test-time.md
+++ b/terms/multiple-crops-at-test-time.md
@@ -1,6 +1,6 @@
 ---
 references:
-- link_title: State of computer vision - Convolutional Neural Networks - deeplearing.ai
+- link_title: State of computer vision - Convolutional Neural Networks - deeplearning.ai
   link_url: https://www.coursera.org/learn/convolutional-neural-networks/lecture/D9ra2/state-of-computer-vision
 related_terms:
 - data-augmentation

--- a/terms/multiple-crops-at-test-time.md
+++ b/terms/multiple-crops-at-test-time.md
@@ -1,12 +1,12 @@
 ---
-title: Multiple crops at test time
-related_terms:
- - data-augmentation
- - alexnet
 references:
- - "[State of computer vision - Convolutional Neural Networks - deeplearing.ai](https://www.coursera.org/learn/convolutional-neural-networks/lecture/D9ra2/state-of-computer-vision)"
+- link_title: State of computer vision - Convolutional Neural Networks - deeplearing.ai
+  link_url: https://www.coursera.org/learn/convolutional-neural-networks/lecture/D9ra2/state-of-computer-vision
+related_terms:
+- data-augmentation
+- alexnet
+title: Multiple crops at test time
 ---
-
 *Multi-crop at test time* is a form of data augmentation that a model uses
 during test time, as opposed to most data augmentation techniques
 that run during training time.

--- a/terms/mutual-information.md
+++ b/terms/mutual-information.md
@@ -1,8 +1,9 @@
 ---
-title: Mutual information
-related_terms:
- - pointwise-mutual-information-pmi
- - variation-of-information-distance
 references:
- - "[Mutual information - Wikipedia](https://en.wikipedia.org/wiki/Mutual_information)"
+- link_title: Mutual information - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Mutual_information
+related_terms:
+- pointwise-mutual-information-pmi
+- variation-of-information-distance
+title: Mutual information
 ---

--- a/terms/n-ary-tree-lstm.md
+++ b/terms/n-ary-tree-lstm.md
@@ -1,8 +1,10 @@
 ---
-title: N-ary Tree LSTM
-related_terms:
- - long-short-term-memory-lstm
- - tree-lstm
 references:
- - "[Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks](https://arxiv.org/abs/1503.00075)"
+- link_title: Improved Semantic Representations From Tree-Structured Long Short-Term
+    Memory Networks
+  link_url: https://arxiv.org/abs/1503.00075
+related_terms:
+- long-short-term-memory-lstm
+- tree-lstm
+title: N-ary Tree LSTM
 ---

--- a/terms/named-entity-recognition-in-query-nerq.md
+++ b/terms/named-entity-recognition-in-query-nerq.md
@@ -1,10 +1,12 @@
 ---
-title: Named Entity Recognition in Query (NERQ)
-related_terms:
- - named-entity-recognition-ner
 references:
- - "[Named Entity Recognition in Query](https://soumen.cse.iitb.ac.in/~soumen/doc/www2013/QirWoo/GuoXCL2009nerq.pdf)"
- - "[Named entity recognition in query - Google Patents](https://www.google.com/patents/US9009134)"
+- link_title: Named Entity Recognition in Query
+  link_url: https://soumen.cse.iitb.ac.in/~soumen/doc/www2013/QirWoo/GuoXCL2009nerq.pdf
+- link_title: Named entity recognition in query - Google Patents
+  link_url: https://www.google.com/patents/US9009134
+related_terms:
+- named-entity-recognition-ner
+title: Named Entity Recognition in Query (NERQ)
 ---
 *Named Entity Recognition in Query* is a phrase used in a research paper and patent from
 Microsoft, referring to the [Named Entity Recognition](/terms/named-entity-recognition-ner/)

--- a/terms/named-entity-recognition-ner.md
+++ b/terms/named-entity-recognition-ner.md
@@ -1,7 +1,9 @@
 ---
-title: Named Entity Recognition (NER)
-related_terms:
- - natural-language-processing
 references:
- - "[Stanford Named Entity Recognizer (NER) - The Stanford Natural Language Processing Group](https://nlp.stanford.edu/software/CRF-NER.shtml)"
+- link_title: Stanford Named Entity Recognizer (NER) - The Stanford Natural Language
+    Processing Group
+  link_url: https://nlp.stanford.edu/software/CRF-NER.shtml
+related_terms:
+- natural-language-processing
+title: Named Entity Recognition (NER)
 ---

--- a/terms/negative-log-likelihood.md
+++ b/terms/negative-log-likelihood.md
@@ -1,6 +1,6 @@
 ---
 references:
-- link_title: hy Minimize Negative Log Likelihood? - Quantivity
+- link_title: Why Minimize Negative Log Likelihood? - Quantivity
   link_url: https://quantivity.wordpress.com/2011/05/23/why-minimize-negative-log-likelihood/
 - link_title: I am wondering why we use negative (log) likelihood sometimes? - Cross
     Validated

--- a/terms/negative-log-likelihood.md
+++ b/terms/negative-log-likelihood.md
@@ -1,6 +1,9 @@
 ---
-title: Negative Log Likelihood
 references:
- - "[hy Minimize Negative Log Likelihood? - Quantivity](https://quantivity.wordpress.com/2011/05/23/why-minimize-negative-log-likelihood/)"
- - "[I am wondering why we use negative (log) likelihood sometimes? - Cross Validated](https://stats.stackexchange.com/questions/141087/i-am-wondering-why-we-use-negative-log-likelihood-sometimes)"
+- link_title: hy Minimize Negative Log Likelihood? - Quantivity
+  link_url: https://quantivity.wordpress.com/2011/05/23/why-minimize-negative-log-likelihood/
+- link_title: I am wondering why we use negative (log) likelihood sometimes? - Cross
+    Validated
+  link_url: https://stats.stackexchange.com/questions/141087/i-am-wondering-why-we-use-negative-log-likelihood-sometimes
+title: Negative Log Likelihood
 ---

--- a/terms/neural-checklist-model.md
+++ b/terms/neural-checklist-model.md
@@ -1,10 +1,11 @@
 ---
-title: Neural checklist model
-related_terms:
- - recurrent-neural-network
- - attention-neural-networks
 references:
- - "[Globally Coherent Text Generation with Neural Checklist Models](https://homes.cs.washington.edu/~yejin/Papers/emnlp16_neuralchecklist.pdf)"
+- link_title: Globally Coherent Text Generation with Neural Checklist Models
+  link_url: https://homes.cs.washington.edu/~yejin/Papers/emnlp16_neuralchecklist.pdf
+related_terms:
+- recurrent-neural-network
+- attention-neural-networks
+title: Neural checklist model
 ---
 Neural checklist models were introduced in the paper [Globally Coherent Text Generation with Neural Checklist Models](https://homes.cs.washington.edu/~yejin/Papers/emnlp16_neuralchecklist.pdf) by Kiddon et al.
 

--- a/terms/neural-turing-machine-ntm.md
+++ b/terms/neural-turing-machine-ntm.md
@@ -1,14 +1,15 @@
 ---
-title: Neural Turing Machine (NTM)
-related_terms:
- - recurrent-neural-network
- - neural-network
- - long-short-term-memory
 references:
- - "[Neural Turing Machine - Wikipedia](https://en.wikipedia.org/wiki/Neural_Turing_machine)"
- - "[Neural Turing Machines](https://arxiv.org/pdf/1410.5401.pdf)"
+- link_title: Neural Turing Machine - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Neural_Turing_machine
+- link_title: Neural Turing Machines
+  link_url: https://arxiv.org/pdf/1410.5401.pdf
+related_terms:
+- recurrent-neural-network
+- neural-network
+- long-short-term-memory
+title: Neural Turing Machine (NTM)
 ---
-
 Neural Turing Machines (NTM) consists of a RNN (commonly with LSTM), and a memory bank, where the neural network can make write and read operations. By making each operation of the NTM differentiable, it can be trained efficiently trained with gradient descent.
 
 The main idea of the NTM is to use the memory bank -- a large, addressable memory -- to give a memory to the RNN so that it can read and write to, yielding a practical mechanism to learn programs. The NTM has been shown to be able to infer simple algorithms, such as copying, sorting and associative recall from input and output examples.

--- a/terms/no-free-lunch-nfl-theorem.md
+++ b/terms/no-free-lunch-nfl-theorem.md
@@ -1,10 +1,13 @@
 ---
-title: No Free Lunch (NFL) theorem
-related_terms:
- - optimization
 references:
- - "[Doesn't the NFL theorem show that black box optimization is flawed? - Black Box Optimization Competition](https://bbcomp.ini.rub.de/faq.html#q20)"
- - "[No free lunch theorem - Wikipedia](https://en.wikipedia.org/wiki/No_free_lunch_theorem)"
+- link_title: Doesn't the NFL theorem show that black box optimization is flawed?
+    - Black Box Optimization Competition
+  link_url: https://bbcomp.ini.rub.de/faq.html#q20
+- link_title: No free lunch theorem - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/No_free_lunch_theorem
+related_terms:
+- optimization
+title: No Free Lunch (NFL) theorem
 ---
 The "No Free Lunch" theorem is the idea that all optimizers perform equally well
 when averaged across all possible optimization problems.

--- a/terms/nonparametric-regression.md
+++ b/terms/nonparametric-regression.md
@@ -1,7 +1,8 @@
 ---
-title: Nonparametric regression
-related_terms:
- - additive-model
 references:
- - "[Nonparametric regression - Wikipedia](https://en.wikipedia.org/wiki/Nonparametric_regression)"
+- link_title: Nonparametric regression - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Nonparametric_regression
+related_terms:
+- additive-model
+title: Nonparametric regression
 ---

--- a/terms/nonparametric.md
+++ b/terms/nonparametric.md
@@ -1,7 +1,8 @@
 ---
-title: Nonparametric
-related_terms:
- - nonparametric-clustering
 references:
- - "[Nonparametric statistics - Wikipedia](https://en.wikipedia.org/wiki/Nonparametric_statistics)"
+- link_title: Nonparametric statistics - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Nonparametric_statistics
+related_terms:
+- nonparametric-clustering
+title: Nonparametric
 ---

--- a/terms/one-hot-encoding.md
+++ b/terms/one-hot-encoding.md
@@ -1,10 +1,12 @@
 ---
-title: One-hot encoding
-related_terms:
- - distributed-representation
 references:
- - "[One-hot - Wikipedia](https://en.wikipedia.org/wiki/One-hot)"
- - "[What is one hot encoding and when is it used in data science?](https://www.quora.com/What-is-one-hot-encoding-and-when-is-it-used-in-data-science)"
+- link_title: One-hot - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/One-hot
+- link_title: What is one hot encoding and when is it used in data science?
+  link_url: https://www.quora.com/What-is-one-hot-encoding-and-when-is-it-used-in-data-science
+related_terms:
+- distributed-representation
+title: One-hot encoding
 ---
 *One-hot encoding* refers to a way of transforming data into vectors
 where all components are 0, except for one component with a value of 1,

--- a/terms/out-of-core.md
+++ b/terms/out-of-core.md
@@ -1,8 +1,10 @@
 ---
-title: Out-of-core
 references:
- - "[Out-of-core algorithm](https://en.wikipedia.org/wiki/Out-of-core_algorithm)"
- - "[Scaling with instances using out-of-core learning - scikit-learn documentation](http://scikit-learn.org/stable/modules/scaling_strategies.html#scaling-with-instances-using-out-of-core-learning)"
+- link_title: Out-of-core algorithm
+  link_url: https://en.wikipedia.org/wiki/Out-of-core_algorithm
+- link_title: Scaling with instances using out-of-core learning - scikit-learn documentation
+  link_url: http://scikit-learn.org/stable/modules/scaling_strategies.html#scaling-with-instances-using-out-of-core-learning
+title: Out-of-core
 ---
 The term *out-of-core* typically refers to processing data that is too large
 to fit into a computer's main memory.

--- a/terms/overfitting.md
+++ b/terms/overfitting.md
@@ -1,9 +1,10 @@
 ---
-title: Overfitting
-related_terms:
- - supervised-learning
 references:
- - "[Overfitting - Wikipedia](https://en.wikipedia.org/wiki/Overfitting)"
+- link_title: Overfitting - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Overfitting
+related_terms:
+- supervised-learning
+title: Overfitting
 ---
 Overfitting is when a statistical model learns patterns in the training
 data that are too complex to generalize well.

--- a/terms/pagerank.md
+++ b/terms/pagerank.md
@@ -1,5 +1,6 @@
 ---
-title: PageRank
 references:
- - "[PageRank - Wikipedia](https://en.wikipedia.org/wiki/PageRank)"
+- link_title: PageRank - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/PageRank
+title: PageRank
 ---

--- a/terms/part-of-speech-pos-tagging.md
+++ b/terms/part-of-speech-pos-tagging.md
@@ -1,9 +1,10 @@
 ---
-title: Part-of-Speech (POS) Tagging
-related_terms:
- - natural-language-processing
 references:
- - "[Part-of-speech tagging](https://en.wikipedia.org/wiki/Part-of-speech_tagging)"
+- link_title: Part-of-speech tagging
+  link_url: https://en.wikipedia.org/wiki/Part-of-speech_tagging
+related_terms:
+- natural-language-processing
+title: Part-of-Speech (POS) Tagging
 ---
 Part-of-Speech tagging is the process of reading
 natural language text and assigning parts of speech to each

--- a/terms/passive-aggressive-algorithm.md
+++ b/terms/passive-aggressive-algorithm.md
@@ -1,6 +1,8 @@
 ---
-title: Passive-Aggressive Algorithm
 references:
- - "[Online Passive-Aggressive Algorithms](http://jmlr.csail.mit.edu/papers/volume7/crammer06a/crammer06a.pdf)"
- - "[Passive Aggressive Algorithms - scikit-learn Documentation](http://scikit-learn.org/stable/modules/linear_model.html#passive-aggressive)"
+- link_title: Online Passive-Aggressive Algorithms
+  link_url: http://jmlr.csail.mit.edu/papers/volume7/crammer06a/crammer06a.pdf
+- link_title: Passive Aggressive Algorithms - scikit-learn Documentation
+  link_url: http://scikit-learn.org/stable/modules/linear_model.html#passive-aggressive
+title: Passive-Aggressive Algorithm
 ---

--- a/terms/pca-color-augmentation.md
+++ b/terms/pca-color-augmentation.md
@@ -1,13 +1,15 @@
 ---
-title: PCA Color Augmentation
-related_terms:
- - principal-component-analysis-pca
- - data-augmentation
 references:
- - "[ImageNet Classification with Deep Convolutional
-Neural Networks](https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf)"
- - "[Fancy PCA (Data Augmentation) with Scikit-Image](https://deshanadesai.github.io/notes/Fancy-PCA-with-Scikit-Image)"
- - "[Data Augmentation - Convolutional Neural Networks - deeplearning.ai](https://www.coursera.org/learn/convolutional-neural-networks/lecture/AYzbX/data-augmentation)"
+- link_title: ImageNet Classification with Deep Convolutional Neural Networks
+  link_url: https://papers.nips.cc/paper/4824-imagenet-classification-with-deep-convolutional-neural-networks.pdf
+- link_title: Fancy PCA (Data Augmentation) with Scikit-Image
+  link_url: https://deshanadesai.github.io/notes/Fancy-PCA-with-Scikit-Image
+- link_title: Data Augmentation - Convolutional Neural Networks - deeplearning.ai
+  link_url: https://www.coursera.org/learn/convolutional-neural-networks/lecture/AYzbX/data-augmentation
+related_terms:
+- principal-component-analysis-pca
+- data-augmentation
+title: PCA Color Augmentation
 ---
 The term *PCA Color Augmentation* refers to a type of
 [data augmentation][1] technique

--- a/terms/pixel-recurrent-neural-network.md
+++ b/terms/pixel-recurrent-neural-network.md
@@ -1,7 +1,8 @@
 ---
-title: Pixel Recurrent Neural Network
-related_terms:
- - recurrent-neural-network
 references:
- - "[Pixel Recurrent Neural Networks](https://arxiv.org/abs/1601.06759)"
+- link_title: Pixel Recurrent Neural Networks
+  link_url: https://arxiv.org/abs/1601.06759
+related_terms:
+- recurrent-neural-network
+title: Pixel Recurrent Neural Network
 ---

--- a/terms/poisson-additive-co-clustering-paco.md
+++ b/terms/poisson-additive-co-clustering-paco.md
@@ -1,9 +1,10 @@
 ---
-title: Poisson Additive Co-Clustering (PACO)
-related_terms:
- - accams
- - co-clustering
- - additive-model
 references:
- - "[Explaining reviews and ratings with PACO: Poisson Additive Co-Clustering](https://arxiv.org/abs/1512.01845)"
+- link_title: 'Explaining reviews and ratings with PACO: Poisson Additive Co-Clustering'
+  link_url: https://arxiv.org/abs/1512.01845
+related_terms:
+- accams
+- co-clustering
+- additive-model
+title: Poisson Additive Co-Clustering (PACO)
 ---

--- a/terms/policy-gradient.md
+++ b/terms/policy-gradient.md
@@ -1,9 +1,10 @@
 ---
-title: Policy Gradient
-related_terms:
- - reinforcement-learning
- - trust-region-policy-optimization
- - gradient
 references:
- - "[Policy gradient methods - Scholarpedia](http://www.scholarpedia.org/article/Policy_gradient_methods)"
+- link_title: Policy gradient methods - Scholarpedia
+  link_url: http://www.scholarpedia.org/article/Policy_gradient_methods
+related_terms:
+- reinforcement-learning
+- trust-region-policy-optimization
+- gradient
+title: Policy Gradient
 ---

--- a/terms/polya-urn-model.md
+++ b/terms/polya-urn-model.md
@@ -1,7 +1,8 @@
 ---
-title: Pólya urn model
-related_terms:
- - chinese-restaurant-process
 references:
- - "[Pólya urn model - Wikipedia](https://en.wikipedia.org/wiki/P%C3%B3lya_urn_model)"
+- link_title: "P\xF3lya urn model - Wikipedia"
+  link_url: https://en.wikipedia.org/wiki/P%C3%B3lya_urn_model
+related_terms:
+- chinese-restaurant-process
+title: "P\xF3lya urn model"
 ---

--- a/terms/pooling-layer.md
+++ b/terms/pooling-layer.md
@@ -1,9 +1,10 @@
 ---
-title: Pooling layer
-related_terms:
- - convolutional-neural-network-cnn
 references:
- - "[Pooling layer - CS231n Notes](http://cs231n.github.io/convolutional-networks/#pool)"
+- link_title: Pooling layer - CS231n Notes
+  link_url: http://cs231n.github.io/convolutional-networks/#pool
+related_terms:
+- convolutional-neural-network-cnn
+title: Pooling layer
 ---
 A *pooling layer* is a common type of layer in a
 [convolutional neural network (CNN)][1]. A pooling layer does not contain

--- a/terms/provenance-tracking.md
+++ b/terms/provenance-tracking.md
@@ -1,8 +1,11 @@
 ---
-title: Provenance tracking
 references:
- - "[Provenance tracking - Best practices for data management in neurophysiology](http://rrcns.readthedocs.io/en/latest/provenance_tracking.html)"
- - "[Data Science Workflow: Overview and Challenges - Communications of the ACM](https://cacm.acm.org/blogs/blog-cacm/169199-data-science-workflow-overview-and-challenges/fulltext)"
+- link_title: Provenance tracking - Best practices for data management in neurophysiology
+  link_url: http://rrcns.readthedocs.io/en/latest/provenance_tracking.html
+- link_title: 'Data Science Workflow: Overview and Challenges - Communications of
+    the ACM'
+  link_url: https://cacm.acm.org/blogs/blog-cacm/169199-data-science-workflow-overview-and-challenges/fulltext
+title: Provenance tracking
 ---
 In data acquisition, provenance tracking is keeping track of
 "where each piece of data comes from and whether it is still up-to-date".

--- a/terms/random-initialization.md
+++ b/terms/random-initialization.md
@@ -1,10 +1,13 @@
 ---
-title: Random initialization
-related_terms:
- - symmetry-breaking
 references:
- - "[Why doesn't backpropagation work when you initialize the weights the same value? -- Cross Validated](https://stats.stackexchange.com/questions/45087/why-doesnt-backpropagation-work-when-you-initialize-the-weights-the-same-value)"
- - "[Random Initialization - Coursera Machine Learning](https://www.coursera.org/learn/machine-learning/lecture/ND5G5/random-initialization)"
+- link_title: Why doesn't backpropagation work when you initialize the weights the
+    same value? -- Cross Validated
+  link_url: https://stats.stackexchange.com/questions/45087/why-doesnt-backpropagation-work-when-you-initialize-the-weights-the-same-value
+- link_title: Random Initialization - Coursera Machine Learning
+  link_url: https://www.coursera.org/learn/machine-learning/lecture/ND5G5/random-initialization
+related_terms:
+- symmetry-breaking
+title: Random initialization
 ---
 Random initialization refers to the practice of using random numbers
 to initialize the weights of a machine learning model.

--- a/terms/random-optimization.md
+++ b/terms/random-optimization.md
@@ -1,5 +1,6 @@
 ---
-title: Random optimization
 references:
- - "[Random optimization - Wikipedia](https://en.wikipedia.org/wiki/Random_optimization)"
+- link_title: Random optimization - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Random_optimization
+title: Random optimization
 ---

--- a/terms/rectified-linear-unit-relu.md
+++ b/terms/rectified-linear-unit-relu.md
@@ -1,11 +1,14 @@
 ---
-title: Rectified Linear Unit (ReLU)
-related_terms:
- - activation-function
- - neural-network
 references:
- - "[Why do we use ReLU in neural networks and how do we use it?](https://stats.stackexchange.com/questions/226923/why-do-we-use-relu-in-neural-networks-and-how-do-we-use-it)"
- - "[What are the advantages of ReLU over sigmoid function in deep neural networks?](https://stats.stackexchange.com/questions/126238/what-are-the-advantages-of-relu-over-sigmoid-function-in-deep-neural-networks)"
+- link_title: Why do we use ReLU in neural networks and how do we use it?
+  link_url: https://stats.stackexchange.com/questions/226923/why-do-we-use-relu-in-neural-networks-and-how-do-we-use-it
+- link_title: What are the advantages of ReLU over sigmoid function in deep neural
+    networks?
+  link_url: https://stats.stackexchange.com/questions/126238/what-are-the-advantages-of-relu-over-sigmoid-function-in-deep-neural-networks
+related_terms:
+- activation-function
+- neural-network
+title: Rectified Linear Unit (ReLU)
 ---
 A Rectified Linear Unit is a common name for a neuron (the "unit")
 with an activation function of $f(x) = \max(0,x)$.

--- a/terms/recurrent-neural-network-language-model-rnnlm.md
+++ b/terms/recurrent-neural-network-language-model-rnnlm.md
@@ -1,11 +1,12 @@
 ---
-title: Recurrent Neural Network Language Model (RNNLM)
-related_terms:
- - natural-language-processing
- - recurrent-neural-network
- - neural-network
 references:
- - "[Recurrent Neural Networks - Tutorials - TensorFlow Documentation](https://www.tensorflow.org/tutorials/recurrent#language_modeling)"
+- link_title: Recurrent Neural Networks - Tutorials - TensorFlow Documentation
+  link_url: https://www.tensorflow.org/tutorials/recurrent#language_modeling
+related_terms:
+- natural-language-processing
+- recurrent-neural-network
+- neural-network
+title: Recurrent Neural Network Language Model (RNNLM)
 ---
 A Recurrent Neural Network Language Model (RNNLM) is
 a recurrent neural network tasked with modeling

--- a/terms/recurrent-neural-network.md
+++ b/terms/recurrent-neural-network.md
@@ -1,14 +1,15 @@
 ---
-title: Recurrent Neural Network
-related_terms:
- - recursive-neural-network
- - neural-network
- - long-short-term-memory
 references:
- - "[Recurrent neural networks - Wikipedia](https://en.wikipedia.org/wiki/Recurrent_neural_network)"
- - "[Recurrent neural networks](https://crl.ucsd.edu/~elman/Papers/fsit.pdf)"
+- link_title: Recurrent neural networks - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Recurrent_neural_network
+- link_title: Recurrent neural networks
+  link_url: https://crl.ucsd.edu/~elman/Papers/fsit.pdf
+related_terms:
+- recursive-neural-network
+- neural-network
+- long-short-term-memory
+title: Recurrent Neural Network
 ---
-
 Recurrent neural networks (RNN) are feed-forward neural networks, but differently than traditional feed-forward models, RNNs contain an internal memory. A RNN have an internal loop that allows information to persist in the network. Neurons receive information not just from the previous layer, but also from themselves from the previous pass. This means that the order of inputs to the RNN matter, and may give different results with different order, as RNNs have state.
 
 RNNs are particularly sensitive to the vanishing and exploding gradient problems, where depending on the activation functions used, the information can get lost over time. [Long short-term memory networks][1](LSTMs) addresses this problem. RNNs are commonly used with sequential data, due to the fact that an RNN is sensitive to the order of the inputs, like in the natural language processing area. Common examples of sequential data includes texts, audio and video.

--- a/terms/reinforce-policy-gradient-algorithm.md
+++ b/terms/reinforce-policy-gradient-algorithm.md
@@ -1,7 +1,9 @@
 ---
-title: REINFORCE Policy Gradient Algorithm
-related_terms:
- - reinforcement-learning
 references:
- - "[Simple statistical gradient-following algorithms for connectionist reinforcement learning](http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.129.8871)"
+- link_title: Simple statistical gradient-following algorithms for connectionist reinforcement
+    learning
+  link_url: http://citeseer.ist.psu.edu/viewdoc/summary?doi=10.1.1.129.8871
+related_terms:
+- reinforcement-learning
+title: REINFORCE Policy Gradient Algorithm
 ---

--- a/terms/reparameterization-trick.md
+++ b/terms/reparameterization-trick.md
@@ -1,9 +1,13 @@
 ---
-title: Reparameterization trick
-related_terms:
- - variational-autoencoder-vae
 references:
- - "[Auto-Encoding Variational Bayes](https://arxiv.org/abs/1312.6114)"
- - "[How does the reparameterization trick for VAEs work and why is it important? - Cross Validated](https://stats.stackexchange.com/questions/199605/how-does-the-reparameterization-trick-for-vaes-work-and-why-is-it-important)"
- - "[Variational Auto-Encoders and Extensions - NIPS 2015 workshop](http://dpkingma.com/wordpress/wp-content/uploads/2015/12/talk_nips_workshop_2015.pdf)"
+- link_title: Auto-Encoding Variational Bayes
+  link_url: https://arxiv.org/abs/1312.6114
+- link_title: How does the reparameterization trick for VAEs work and why is it important?
+    - Cross Validated
+  link_url: https://stats.stackexchange.com/questions/199605/how-does-the-reparameterization-trick-for-vaes-work-and-why-is-it-important
+- link_title: Variational Auto-Encoders and Extensions - NIPS 2015 workshop
+  link_url: http://dpkingma.com/wordpress/wp-content/uploads/2015/12/talk_nips_workshop_2015.pdf
+related_terms:
+- variational-autoencoder-vae
+title: Reparameterization trick
 ---

--- a/terms/representation-learning.md
+++ b/terms/representation-learning.md
@@ -1,7 +1,10 @@
 ---
-title: Representation learning
 references:
- - "[Feature learning - Wikipedia](https://en.wikipedia.org/wiki/Feature_learning)"
- - "[Representation Learning: A Review and New Perspectives](http://www.cl.uni-heidelberg.de/courses/ws14/deepl/BengioETAL12.pdf)"
- - "[Representation Learning - Deep Learning Book](http://www.deeplearningbook.org/contents/representation.html)"
+- link_title: Feature learning - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Feature_learning
+- link_title: 'Representation Learning: A Review and New Perspectives'
+  link_url: http://www.cl.uni-heidelberg.de/courses/ws14/deepl/BengioETAL12.pdf
+- link_title: Representation Learning - Deep Learning Book
+  link_url: http://www.deeplearningbook.org/contents/representation.html
+title: Representation learning
 ---

--- a/terms/resnet.md
+++ b/terms/resnet.md
@@ -1,11 +1,14 @@
 ---
-title: ResNet
-related_terms:
- - convolutional-neural-network-cnn
 references:
- - "[Case Studies - Stanford CS231n Convolutional Neural Networks](http://cs231n.github.io/convolutional-networks/#case)"
- - "[Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385)"
- - "[Identity Mappings in Deep Residual Networks](https://arxiv.org/abs/1603.05027)"
+- link_title: Case Studies - Stanford CS231n Convolutional Neural Networks
+  link_url: http://cs231n.github.io/convolutional-networks/#case
+- link_title: Deep Residual Learning for Image Recognition
+  link_url: https://arxiv.org/abs/1512.03385
+- link_title: Identity Mappings in Deep Residual Networks
+  link_url: https://arxiv.org/abs/1603.05027
+related_terms:
+- convolutional-neural-network-cnn
+title: ResNet
 ---
 ResNet stands for "Residual Network" and was introduced in the paper
 [Deep Residual Learning for Image Recognition](https://arxiv.org/abs/1512.03385).

--- a/terms/same-convolution.md
+++ b/terms/same-convolution.md
@@ -1,11 +1,13 @@
 ---
-title: Same convolution
-related_terms:
- - convolution
- - convolutional-neural-network-cnn
- - padding-convolution
 references:
- - "[What is the difference between 'SAME' and 'VALID' padding in tf.nn.max_pool of tensorflow?](https://stackoverflow.com/questions/37674306/what-is-the-difference-between-same-and-valid-padding-in-tf-nn-max-pool-of-t)"
+- link_title: What is the difference between 'SAME' and 'VALID' padding in tf.nn.max_pool
+    of tensorflow?
+  link_url: https://stackoverflow.com/questions/37674306/what-is-the-difference-between-same-and-valid-padding-in-tf-nn-max-pool-of-t
+related_terms:
+- convolution
+- convolutional-neural-network-cnn
+- padding-convolution
+title: Same convolution
 ---
 A *same convolution* is a type of convolution where the output
 matrix is of the same dimension as the input matrix.

--- a/terms/search-based-software-engineering-sbse.md
+++ b/terms/search-based-software-engineering-sbse.md
@@ -1,9 +1,9 @@
 ---
-title: Search-based software engineering (SBSE)
 references:
- - "[Search-based software engineering - Wikipedia](https://en.wikipedia.org/wiki/Search-based_software_engineering)"
+- link_title: Search-based software engineering - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Search-based_software_engineering
+title: Search-based software engineering (SBSE)
 ---
-
 Search-based software engineering applies search and
 optimization techniques to software engineering problems.
 

--- a/terms/self-supervised-learning.md
+++ b/terms/self-supervised-learning.md
@@ -1,14 +1,17 @@
 ---
-title: Self-supervised learning
-related_terms:
- - unsupervised-learning
- - supervised-learning
- - autoencoder
- - word2vec
- - word-embedding
 references:
- - "[Is there any difference between distant supervision, self-training, self-supervised learning, and weak supervision? - Cross validated](https://stats.stackexchange.com/questions/125957/is-there-any-difference-between-distant-supervision-self-training-self-supervi)"
- - "[Self-supervised learning - Virginia R. de Sa](http://www.cogsci.ucsd.edu/academicPubs/desa/resareasfile/node3.html)"
+- link_title: Is there any difference between distant supervision, self-training,
+    self-supervised learning, and weak supervision? - Cross validated
+  link_url: https://stats.stackexchange.com/questions/125957/is-there-any-difference-between-distant-supervision-self-training-self-supervi
+- link_title: Self-supervised learning - Virginia R. de Sa
+  link_url: http://www.cogsci.ucsd.edu/academicPubs/desa/resareasfile/node3.html
+related_terms:
+- unsupervised-learning
+- supervised-learning
+- autoencoder
+- word2vec
+- word-embedding
+title: Self-supervised learning
 ---
 Self-supervised learning is a type of
 [supervised learning](/terms/supervised-learning/)

--- a/terms/semantic-hashing.md
+++ b/terms/semantic-hashing.md
@@ -1,10 +1,11 @@
 ---
-title: Semantic hashing
-related_terms:
- - autoencoder
- - word-embedding
 references:
- - "[Semantic Hashing](https://www.cs.utoronto.ca/~rsalakhu/papers/semantic_final.pdf)"
+- link_title: Semantic Hashing
+  link_url: https://www.cs.utoronto.ca/~rsalakhu/papers/semantic_final.pdf
+related_terms:
+- autoencoder
+- word-embedding
+title: Semantic hashing
 ---
 A *hash* is a small, lossy representation of a data point. Typically hashes
 are fixed-sized representations of variable-sized data.

--- a/terms/semi-supervised-learning.md
+++ b/terms/semi-supervised-learning.md
@@ -1,13 +1,17 @@
 ---
-title: Semi-supervised learning
-related_terms:
- - unsupervised-learning
- - supervised-learning
- - self-supervised-learning
 references:
- - "[Is there any difference between distant supervision, self-training, self-supervised learning, and weak supervision? - Cross validated](https://stats.stackexchange.com/questions/125957/is-there-any-difference-between-distant-supervision-self-training-self-supervi)"
- - "[Self-supervised learning - Virginia R. de Sa](http://www.cogsci.ucsd.edu/academicPubs/desa/resareasfile/node3.html)"
- - "[Semi-supervised learning - Wikipedia](https://en.wikipedia.org/wiki/Semi-supervised_learning)"
+- link_title: Is there any difference between distant supervision, self-training,
+    self-supervised learning, and weak supervision? - Cross validated
+  link_url: https://stats.stackexchange.com/questions/125957/is-there-any-difference-between-distant-supervision-self-training-self-supervi
+- link_title: Self-supervised learning - Virginia R. de Sa
+  link_url: http://www.cogsci.ucsd.edu/academicPubs/desa/resareasfile/node3.html
+- link_title: Semi-supervised learning - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Semi-supervised_learning
+related_terms:
+- unsupervised-learning
+- supervised-learning
+- self-supervised-learning
+title: Semi-supervised learning
 ---
 Semi-supervised learning mixes labeled and labeled data
 to produce better models.

--- a/terms/sense2vec.md
+++ b/terms/sense2vec.md
@@ -1,12 +1,15 @@
 ---
-title: sense2vec
-related_terms:
- - word2vec
- - word-embedding
- - glove-word-embeddings
 references:
- - "[sense2vec - A Fast and Accurate Method for Word Sense Disambiguation In Neural Word Embeddings](https://arxiv.org/abs/1511.06388)"
- - "[Sense2vec with spaCy and Gensim - Explosion AI](https://explosion.ai/blog/sense2vec-with-spacy)"
+- link_title: sense2vec - A Fast and Accurate Method for Word Sense Disambiguation
+    In Neural Word Embeddings
+  link_url: https://arxiv.org/abs/1511.06388
+- link_title: Sense2vec with spaCy and Gensim - Explosion AI
+  link_url: https://explosion.ai/blog/sense2vec-with-spacy
+related_terms:
+- word2vec
+- word-embedding
+- glove-word-embeddings
+title: sense2vec
 ---
 sense2vec refers to a system in a paper titled
 [sense2vec - A Fast and Accurate Method for Word Sense Disambiguation In Neural Word Embeddings](https://arxiv.org/abs/1511.06388).

--- a/terms/sequence-to-sequence-learning-seq2seq.md
+++ b/terms/sequence-to-sequence-learning-seq2seq.md
@@ -1,11 +1,13 @@
 ---
-title: Sequence to Sequence Learning (seq2seq)
-related_terms:
- - long-short-term-memory-lstm
- - recurrent-neural-network
 references:
- - "[Sequence-to-Sequence Models - TensorFlow Tutorials](https://www.tensorflow.org/tutorials/seq2seq)"
- - "[Sequence to Sequence Learning with Neural Networks](https://arxiv.org/abs/1409.3215)"
+- link_title: Sequence-to-Sequence Models - TensorFlow Tutorials
+  link_url: https://www.tensorflow.org/tutorials/seq2seq
+- link_title: Sequence to Sequence Learning with Neural Networks
+  link_url: https://arxiv.org/abs/1409.3215
+related_terms:
+- long-short-term-memory-lstm
+- recurrent-neural-network
+title: Sequence to Sequence Learning (seq2seq)
 ---
 This typically refers to the method originally described by Sutskever et al. in the paper
 [Sequence to Sequence Learning with Neural Networks][1].

--- a/terms/sequential-model-based-optimization-smbo.md
+++ b/terms/sequential-model-based-optimization-smbo.md
@@ -1,8 +1,10 @@
 ---
-title: Sequential Model-Based Optimization (SMBO)
-related_terms:
- - bayesian-optimization
- - structured-bayesian-optimization-sbo
 references:
- - "[Sequential Model-Based Optimization for General Algorithm Configuration (extended version)](https://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf)"
+- link_title: Sequential Model-Based Optimization for General Algorithm Configuration
+    (extended version)
+  link_url: https://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf
+related_terms:
+- bayesian-optimization
+- structured-bayesian-optimization-sbo
+title: Sequential Model-Based Optimization (SMBO)
 ---

--- a/terms/sequential-pattern-mining.md
+++ b/terms/sequential-pattern-mining.md
@@ -1,7 +1,8 @@
 ---
-title: Sequential pattern mining
-related_terms:
- - association-rule-mining
 references:
- - "[Sequential pattern mining - Wikipedia](https://en.wikipedia.org/wiki/Sequential_pattern_mining)"
+- link_title: Sequential pattern mining - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Sequential_pattern_mining
+related_terms:
+- association-rule-mining
+title: Sequential pattern mining
 ---

--- a/terms/smooth-support-vector-machine-ssvm.md
+++ b/terms/smooth-support-vector-machine-ssvm.md
@@ -1,8 +1,8 @@
 ---
-title: Smooth support vector machine (SSVM)
-related_terms:
- - support-vector-machine-svm
 references:
- - "[SSVM: A Smooth Support Vector Machine
-for Classification](http://jupiter.math.nctu.edu.tw/~yuhjye/assets/file/publications/conference_papers/C29_SSVM.pdf)"
+- link_title: 'SSVM: A Smooth Support Vector Machine for Classification'
+  link_url: http://jupiter.math.nctu.edu.tw/~yuhjye/assets/file/publications/conference_papers/C29_SSVM.pdf
+related_terms:
+- support-vector-machine-svm
+title: Smooth support vector machine (SSVM)
 ---

--- a/terms/sobel-filter-convolution.md
+++ b/terms/sobel-filter-convolution.md
@@ -1,11 +1,12 @@
 ---
-title: Sobel filter (convolution)
-related_terms:
- - filter-convolution
- - convolution
- - convolutional-neural-network-cnn
 references:
- - "[Sobel operator - Wikipedia](https://en.wikipedia.org/wiki/Sobel_operator)"
+- link_title: Sobel operator - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Sobel_operator
+related_terms:
+- filter-convolution
+- convolution
+- convolutional-neural-network-cnn
+title: Sobel filter (convolution)
 ---
 The Sobel filter is a set of two convolution filters used to detect horizontal
 and vertical edges in images.

--- a/terms/softmax.md
+++ b/terms/softmax.md
@@ -1,9 +1,10 @@
 ---
-title: Softmax
-related_terms:
- - hierarchical-softmax
 references:
- - "[Softmax function - Wikipedia](https://en.wikipedia.org/wiki/Softmax_function)"
+- link_title: Softmax function - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Softmax_function
+related_terms:
+- hierarchical-softmax
+title: Softmax
 ---
 The softmax turns $n$ numbers
 in $\mathbb R^N$ into a probability distribution proportional

--- a/terms/standard-deviation.md
+++ b/terms/standard-deviation.md
@@ -1,7 +1,8 @@
 ---
-title: Standard deviation
-related_terms:
- - variance
 references:
- - "[Standard deviation - Wikipedia](https://en.wikipedia.org/wiki/Standard_deviation)"
+- link_title: Standard deviation - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Standard_deviation
+related_terms:
+- variance
+title: Standard deviation
 ---

--- a/terms/stochastic-convex-hull-sch.md
+++ b/terms/stochastic-convex-hull-sch.md
@@ -1,10 +1,14 @@
 ---
-title: Stochastic convex hull (SCH)
-related_terms:
- - convex-hull
 references:
- - "[On the expected diameter, width, and complexity of a stochastic convex-hull](http://arxiv.org/abs/1704.07028)"
- - "[On the Separability of Stochastic Geometric Objects, with Applications](https://arxiv.org/abs/1603.07021)"
- - "[Convex Hulls under Uncertainty](https://www.cs.ucsb.edu/~suri/psdir/esa14.pdf)"
- - "[Probabilistic Convex Hull Queries over Uncertain Data](http://ieeexplore.ieee.org/document/6858080/)"
+- link_title: On the expected diameter, width, and complexity of a stochastic convex-hull
+  link_url: http://arxiv.org/abs/1704.07028
+- link_title: On the Separability of Stochastic Geometric Objects, with Applications
+  link_url: https://arxiv.org/abs/1603.07021
+- link_title: Convex Hulls under Uncertainty
+  link_url: https://www.cs.ucsb.edu/~suri/psdir/esa14.pdf
+- link_title: Probabilistic Convex Hull Queries over Uncertain Data
+  link_url: http://ieeexplore.ieee.org/document/6858080/
+related_terms:
+- convex-hull
+title: Stochastic convex hull (SCH)
 ---

--- a/terms/structured-bayesian-optimization-sbo.md
+++ b/terms/structured-bayesian-optimization-sbo.md
@@ -1,8 +1,8 @@
 ---
-title: Structured Bayesian optimization (SBO)
-related_terms:
- - bayesian-optimization
 references:
- - "[BOAT: Building Auto-Tuners with Structured Bayesian
-Optimization](https://www.cl.cam.ac.uk/~mks40/pubs/www_2017.pdf)"
+- link_title: 'BOAT: Building Auto-Tuners with Structured Bayesian Optimization'
+  link_url: https://www.cl.cam.ac.uk/~mks40/pubs/www_2017.pdf
+related_terms:
+- bayesian-optimization
+title: Structured Bayesian optimization (SBO)
 ---

--- a/terms/structured-learning.md
+++ b/terms/structured-learning.md
@@ -1,6 +1,8 @@
 ---
-title: Structured learning
 references:
- - "[Structured prediction - Wikipedia](https://en.wikipedia.org/wiki/Structured_prediction)"
- - "[What is structured learning? - PyStruct](http://pystruct.github.io/intro.html#intro)"
+- link_title: Structured prediction - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Structured_prediction
+- link_title: What is structured learning? - PyStruct
+  link_url: http://pystruct.github.io/intro.html#intro
+title: Structured learning
 ---

--- a/terms/symmetry-breaking.md
+++ b/terms/symmetry-breaking.md
@@ -1,8 +1,11 @@
 ---
-title: Symmetry breaking
 references:
- - "[Why doesn't backpropagation work when you initialize the weights the same value? -- Cross Validated](https://stats.stackexchange.com/questions/45087/why-doesnt-backpropagation-work-when-you-initialize-the-weights-the-same-value)"
- - "[Random Initialization - Coursera Machine Learning](https://www.coursera.org/learn/machine-learning/lecture/ND5G5/random-initialization)"
+- link_title: Why doesn't backpropagation work when you initialize the weights the
+    same value? -- Cross Validated
+  link_url: https://stats.stackexchange.com/questions/45087/why-doesnt-backpropagation-work-when-you-initialize-the-weights-the-same-value
+- link_title: Random Initialization - Coursera Machine Learning
+  link_url: https://www.coursera.org/learn/machine-learning/lecture/ND5G5/random-initialization
+title: Symmetry breaking
 ---
 Symmetry breaking refer to a requirement of initializing machine
 learning models like neural networks.

--- a/terms/syntaxnet.md
+++ b/terms/syntaxnet.md
@@ -1,10 +1,13 @@
 ---
-title: SyntaxNet
-related_terms:
- - natural-language-processing
 references:
- - "[Announcing SyntaxNet: The World’s Most Accurate Parser Goes Open Source - Google Research Blog](https://research.googleblog.com/2016/05/announcing-syntaxnet-worlds-most.html)"
- - "[Globally Normalized Transition-Based Neural Networks](https://arxiv.org/abs/1603.06042)"
+- link_title: "Announcing SyntaxNet: The World\u2019s Most Accurate Parser Goes Open\
+    \ Source - Google Research Blog"
+  link_url: https://research.googleblog.com/2016/05/announcing-syntaxnet-worlds-most.html
+- link_title: Globally Normalized Transition-Based Neural Networks
+  link_url: https://arxiv.org/abs/1603.06042
+related_terms:
+- natural-language-processing
+title: SyntaxNet
 ---
 SyntaxNet is a framework for natural language syntactic
 parsers released by Google in 2016.

--- a/terms/tabu-search.md
+++ b/terms/tabu-search.md
@@ -1,6 +1,8 @@
 ---
-title: Tabu Search
 references:
- - "[Tabu Search - Clever Algorithms](http://www.cleveralgorithms.com/nature-inspired/stochastic/tabu_search.html)"
- - "[Tabu search - Wikipedia](https://en.wikipedia.org/wiki/Tabu_search)"
+- link_title: Tabu Search - Clever Algorithms
+  link_url: http://www.cleveralgorithms.com/nature-inspired/stochastic/tabu_search.html
+- link_title: Tabu search - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Tabu_search
+title: Tabu Search
 ---

--- a/terms/temporal-generative-adversarial-network-tgan.md
+++ b/terms/temporal-generative-adversarial-network-tgan.md
@@ -1,7 +1,8 @@
 ---
-title: Temporal Generative Adversarial Network (TGAN)
-related_terms:
- - generative-adversarial-network-gan
 references:
- - "[Temporal Generative Adversarial Networks](https://arxiv.org/abs/1611.06624)"
+- link_title: Temporal Generative Adversarial Networks
+  link_url: https://arxiv.org/abs/1611.06624
+related_terms:
+- generative-adversarial-network-gan
+title: Temporal Generative Adversarial Network (TGAN)
 ---

--- a/terms/termite.md
+++ b/terms/termite.md
@@ -1,11 +1,15 @@
 ---
-title: Termite
-related_terms:
- - latent-dirichlet-allocation-lda
 references:
- - "[Termite: Visualization Techniques for Assessing Textual Topic Models - Stanford Visualization Group](http://vis.stanford.edu/papers/termite)"
- - "[Online Termite Demo](http://vis.stanford.edu/topic-diagnostics/model/silverStandards/)"
- - "[Termite Data Server - Github](https://github.com/uwdata/termite-data-server)"
+- link_title: 'Termite: Visualization Techniques for Assessing Textual Topic Models
+    - Stanford Visualization Group'
+  link_url: http://vis.stanford.edu/papers/termite
+- link_title: Online Termite Demo
+  link_url: http://vis.stanford.edu/topic-diagnostics/model/silverStandards/
+- link_title: Termite Data Server - Github
+  link_url: https://github.com/uwdata/termite-data-server
+related_terms:
+- latent-dirichlet-allocation-lda
+title: Termite
 ---
 Termite is a visual analysis tool to determine the quality of topic models
 like [latent Dirichlet allocation](/terms/latent-dirichlet-allocation-lda/).

--- a/terms/textrank.md
+++ b/terms/textrank.md
@@ -1,9 +1,10 @@
 ---
-title: TextRank
-related_terms:
- - pagerank
 references:
- - "[TextRank: Bringing Order into Texts](http://www.aclweb.org/anthology/W04-3252)"
+- link_title: 'TextRank: Bringing Order into Texts'
+  link_url: http://www.aclweb.org/anthology/W04-3252
+related_terms:
+- pagerank
+title: TextRank
 ---
 TextRank is a graph ranking algorithm applied to text.
 It is useful for various unsupervised learning

--- a/terms/top-1-error-rate.md
+++ b/terms/top-1-error-rate.md
@@ -1,7 +1,8 @@
 ---
-title: Top-1 error rate
 references:
- - "[ImageNet: what is top-1 and top-5 error rate?](https://stats.stackexchange.com/questions/156471/imagenet-what-is-top-1-and-top-5-error-rate)"
+- link_title: 'ImageNet: what is top-1 and top-5 error rate?'
+  link_url: https://stats.stackexchange.com/questions/156471/imagenet-what-is-top-1-and-top-5-error-rate
+title: Top-1 error rate
 ---
 The term *top-1 error rate* refers method of benchmarking
 machine learning models in the ImageNet

--- a/terms/top-5-error-rate.md
+++ b/terms/top-5-error-rate.md
@@ -1,9 +1,10 @@
 ---
-title: Top-5 error rate
-related_terms:
- - top-1-error-rate
 references:
- - "[ImageNet: what is top-1 and top-5 error rate?](https://stats.stackexchange.com/questions/156471/imagenet-what-is-top-1-and-top-5-error-rate)"
+- link_title: 'ImageNet: what is top-1 and top-5 error rate?'
+  link_url: https://stats.stackexchange.com/questions/156471/imagenet-what-is-top-1-and-top-5-error-rate
+related_terms:
+- top-1-error-rate
+title: Top-5 error rate
 ---
 The term *top-5 error rate* refers method of benchmarking
 machine learning models in the ImageNet

--- a/terms/tree-lstm.md
+++ b/terms/tree-lstm.md
@@ -1,9 +1,11 @@
 ---
-title: Tree-LSTM
-related_terms:
- - long-short-term-memory-lstm
 references:
- - "[Improved Semantic Representations From Tree-Structured Long Short-Term Memory Networks](https://arxiv.org/abs/1503.00075)"
+- link_title: Improved Semantic Representations From Tree-Structured Long Short-Term
+    Memory Networks
+  link_url: https://arxiv.org/abs/1503.00075
+related_terms:
+- long-short-term-memory-lstm
+title: Tree-LSTM
 ---
 Tree-LSTMs are a variant of Long Short Term Memory (LSTM) neural networks.
 

--- a/terms/trust-region-policy-optimization.md
+++ b/terms/trust-region-policy-optimization.md
@@ -1,7 +1,8 @@
 ---
-title: Trust Region Policy Optimization (TRPO)
-related_terms:
- - optimization
 references:
- - "[Trust Region Policy Optimization](https://arxiv.org/abs/1502.05477)"
+- link_title: Trust Region Policy Optimization
+  link_url: https://arxiv.org/abs/1502.05477
+related_terms:
+- optimization
+title: Trust Region Policy Optimization (TRPO)
 ---

--- a/terms/valid-convolution.md
+++ b/terms/valid-convolution.md
@@ -1,12 +1,14 @@
 ---
-title: Valid convolution
-related_terms:
- - convolution
- - same-convolution
- - convolutional-neural-network-cnn
- - padding-convolution
 references:
- - "[What is the difference between 'SAME' and 'VALID' padding in tf.nn.max_pool of tensorflow?](https://stackoverflow.com/questions/37674306/what-is-the-difference-between-same-and-valid-padding-in-tf-nn-max-pool-of-t)"
+- link_title: What is the difference between 'SAME' and 'VALID' padding in tf.nn.max_pool
+    of tensorflow?
+  link_url: https://stackoverflow.com/questions/37674306/what-is-the-difference-between-same-and-valid-padding-in-tf-nn-max-pool-of-t
+related_terms:
+- convolution
+- same-convolution
+- convolutional-neural-network-cnn
+- padding-convolution
+title: Valid convolution
 ---
 A *valid convolution* is a type of [convolution][1] operation that does not use any [padding][2] on the input.
 

--- a/terms/variance.md
+++ b/terms/variance.md
@@ -1,7 +1,8 @@
 ---
-title: Variance
 references:
- - "[Variance - Wikipedia](https://en.wikipedia.org/wiki/Variance)"
+- link_title: Variance - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Variance
+title: Variance
 ---
 Wikipedia describes variance as follows:
 

--- a/terms/variation-of-information-distance.md
+++ b/terms/variation-of-information-distance.md
@@ -1,5 +1,6 @@
 ---
-title: Variation of Information distance
 references:
- - "[Variation of information - Wikipedia](https://en.wikipedia.org/wiki/Variation_of_information)"
+- link_title: Variation of information - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Variation_of_information
+title: Variation of Information distance
 ---

--- a/terms/vggnet.md
+++ b/terms/vggnet.md
@@ -1,11 +1,15 @@
 ---
-title: VGGNet
-related_terms:
- - convolutional-neural-network-cnn
 references:
- - "[Very Deep Convolutional Networks for Large-Scale Visual Recognition - Department of Engineering Science, University of Oxford](http://www.robots.ox.ac.uk/~vgg/research/very_deep/)"
- - "[Case Studies - Stanford CS231n Convolutional Neural Networks](http://cs231n.github.io/convolutional-networks/#case)"
- - "[Very Deep Convolutional Networks for Large-Scale Image Recognition](https://arxiv.org/abs/1409.1556)"
+- link_title: Very Deep Convolutional Networks for Large-Scale Visual Recognition
+    - Department of Engineering Science, University of Oxford
+  link_url: http://www.robots.ox.ac.uk/~vgg/research/very_deep/
+- link_title: Case Studies - Stanford CS231n Convolutional Neural Networks
+  link_url: http://cs231n.github.io/convolutional-networks/#case
+- link_title: Very Deep Convolutional Networks for Large-Scale Image Recognition
+  link_url: https://arxiv.org/abs/1409.1556
+related_terms:
+- convolutional-neural-network-cnn
+title: VGGNet
 ---
 VGGNet is a deep convolutional neural network 
 for image recognition, trained by

--- a/terms/weight-sharing.md
+++ b/terms/weight-sharing.md
@@ -1,11 +1,14 @@
 ---
-title: Weight sharing
-related_terms:
- - neural-network
 references:
- - "[Simplifying Neural Networks by Soft Weight-Sharing](http://www.cs.toronto.edu/~fritz/absps/sunspots.pdf)"
- - "[Shared Weights - Convolutional Neural Networks - Deep Learning Tutorial](http://deeplearning.net/tutorial/lenet.html#shared-weights)"
- - "[Soft Weight-Sharing for Neural Network Compression](https://arxiv.org/abs/1702.04008)"
+- link_title: Simplifying Neural Networks by Soft Weight-Sharing
+  link_url: http://www.cs.toronto.edu/~fritz/absps/sunspots.pdf
+- link_title: Shared Weights - Convolutional Neural Networks - Deep Learning Tutorial
+  link_url: http://deeplearning.net/tutorial/lenet.html#shared-weights
+- link_title: Soft Weight-Sharing for Neural Network Compression
+  link_url: https://arxiv.org/abs/1702.04008
+related_terms:
+- neural-network
+title: Weight sharing
 ---
 In neural networks, weight sharing is a way to reduce the number of parameters while allowing
 for more robust feature detection. Reducing the number of parameters can be

--- a/terms/weighted-finite-state-transducer-wfst.md
+++ b/terms/weighted-finite-state-transducer-wfst.md
@@ -1,7 +1,8 @@
 ---
-title: Weighted finite-state transducer (WFST)
-related_terms:
- - finite-state-transducer-fst
 references:
- - "[Weighted automata - Finite-state transducer - Wikipedia](https://en.wikipedia.org/wiki/Finite-state_transducer#Weighted_automata)"
+- link_title: Weighted automata - Finite-state transducer - Wikipedia
+  link_url: https://en.wikipedia.org/wiki/Finite-state_transducer#Weighted_automata
+related_terms:
+- finite-state-transducer-fst
+title: Weighted finite-state transducer (WFST)
 ---

--- a/terms/word2vec.md
+++ b/terms/word2vec.md
@@ -1,13 +1,15 @@
 ---
-title: word2vec
-related_terms:
- - word-embedding
- - skip-gram
- - continuous-bag-of-words-cbow
- - doc2vec
 references:
- - "[Efficient Estimation of Word Representations in Vector Space](https://arxiv.org/abs/1301.3781)"
- - "[Vector Representations of Words - Tutorials - TensorFlow Documentation](https://www.tensorflow.org/tutorials/word2vec)"
+- link_title: Efficient Estimation of Word Representations in Vector Space
+  link_url: https://arxiv.org/abs/1301.3781
+- link_title: Vector Representations of Words - Tutorials - TensorFlow Documentation
+  link_url: https://www.tensorflow.org/tutorials/word2vec
+related_terms:
+- word-embedding
+- skip-gram
+- continuous-bag-of-words-cbow
+- doc2vec
+title: word2vec
 ---
 `word2vec` refers to a pair of models, open-source software, and pre-trained word embeddings
 from Google.

--- a/terms/zero-padding.md
+++ b/terms/zero-padding.md
@@ -1,12 +1,16 @@
 ---
-title: Zero padding
-related_terms:
- - convolutional-neural-network-cnn
- - max-pooling
 references:
- - "[FFT Zero Padding - Bitweenie](http://www.bitweenie.com/listings/fft-zero-padding/)"
- - "[Why should I zero-pad a signal before taking the Fourier transform? - Statistics StackExchange](https://dsp.stackexchange.com/questions/741/why-should-i-zero-pad-a-signal-before-taking-the-fourier-transform)"
- - "[Convolutional Layers: To pad or not to pad?](https://stats.stackexchange.com/questions/246512/convolutional-layers-to-pad-or-not-to-pad)"
+- link_title: FFT Zero Padding - Bitweenie
+  link_url: http://www.bitweenie.com/listings/fft-zero-padding/
+- link_title: Why should I zero-pad a signal before taking the Fourier transform?
+    - Statistics StackExchange
+  link_url: https://dsp.stackexchange.com/questions/741/why-should-i-zero-pad-a-signal-before-taking-the-fourier-transform
+- link_title: 'Convolutional Layers: To pad or not to pad?'
+  link_url: https://stats.stackexchange.com/questions/246512/convolutional-layers-to-pad-or-not-to-pad
+related_terms:
+- convolutional-neural-network-cnn
+- max-pooling
+title: Zero padding
 ---
 ## Signal processing
 In signal processing, zero padding refers to the practice of adding zeroes to a time-domain

--- a/terms/zero-shot-learning.md
+++ b/terms/zero-shot-learning.md
@@ -1,11 +1,13 @@
 ---
-title: Zero-shot learning
-related_terms:
- - one-shot-learning
- - representation-learning
 references:
- - "[What is zero-shot learning?](https://www.quora.com/What-is-zero-shot-learning)"
- - "[Representation Learning - Deep Learning Book](http://www.deeplearningbook.org/contents/representation.html)"
+- link_title: What is zero-shot learning?
+  link_url: https://www.quora.com/What-is-zero-shot-learning
+- link_title: Representation Learning - Deep Learning Book
+  link_url: http://www.deeplearningbook.org/contents/representation.html
+related_terms:
+- one-shot-learning
+- representation-learning
+title: Zero-shot learning
 ---
 Ian Goodfellow in [a Quora answer][1] defines zero-shot learning as the following:
 


### PR DESCRIPTION
This pull request changes the schema for adding references.

Previously we added references by creating a list of Markdown strings. This was difficult to write and difficult to parse.

```yaml
references:
 - "[Adaptive Subgradient Methods for Online Learning and Stochastic Optimization](http://jmlr.org/papers/v12/duchi11a.html)"
 - "[An overview of gradient descent optimization algorithms - Sebiastian Ruder](http://sebastianruder.com/optimizing-gradient-descent/)"
```

Now we are using the Netlify CMS, it makes a lot more sense to have the URL and title text as separate fields. This is part of a broader shift from an text editor-based editing workflow to a CMS-based editing workflow.

In the YAML front matter, this is what the new reference style looks like:

```yaml
references:
- link_title: Adaptive Subgradient Methods for Online Learning and Stochastic Optimization
  link_url: http://jmlr.org/papers/v12/duchi11a.html
- link_title: An overview of gradient descent optimization algorithms - Sebiastian
    Ruder
  link_url: http://sebastianruder.com/optimizing-gradient-descent/
```

Additionally, we now list the website's domain name in the hyperlink title.
