### PR TITLE
Use the jekyll-toc plugin to generate Tables of Contents

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GEM
       sass (~> 3.4)
     jekyll-sitemap (1.1.1)
       jekyll (~> 3.3)
-    jekyll-toc (0.4.0)
+    jekyll-toc (0.5.0)
       nokogiri (~> 1.6)
     jekyll-watch (1.5.1)
       listen (~> 3.0)

--- a/_config.yml
+++ b/_config.yml
@@ -13,6 +13,7 @@ defaults:
       path: "terms"
     values:
       layout: page
+      toc: true
 pandoc:
   extensions:
     - normalize
@@ -36,6 +37,10 @@ exclude:
   - Dockerfile
   - build.sh
   - serve.sh
+
+toc:
+  min_level: 1 # default: 1
+  max_level: 3 # default: 6
 
 algolia:
   application_id: O2TYYMG19M

--- a/_includes/references.html
+++ b/_includes/references.html
@@ -1,5 +1,6 @@
+ {% assign header = include.header | default: "h2" %}
 {% if include.page.references %}
-  <h2>References</h2>
+  <{{ header }}>References</{{ header }}>
   <ul>
   {% for ref in include.page.references %}
     {% assign link_parts_1 = ref.link_url | split: "://" %}

--- a/_includes/related_terms.html
+++ b/_includes/related_terms.html
@@ -1,3 +1,4 @@
+ {% assign header = include.header | default: "h2" %}
 {% assign page_filename = include.page.path | split: "/" | last | split: "." | first %}
 {% capture outbound_link_term_urls_str %}{% for term in page.related_terms %}/terms/{{term}}/<br>{% endfor %}
 {% endcapture %}
@@ -30,7 +31,7 @@
 {% endfor %}
 {% endcapture %}
 {% if display_the_terms %}
-<h2>Related Terms</h2>
+<{{ header }}>Related Terms</{{ header }}>
 <ul>
     {{ term_list }}
 </ul>

--- a/_includes/synonyms.html
+++ b/_includes/synonyms.html
@@ -1,7 +1,8 @@
+  {% assign header = include.header | default: "h2" %}
   {% assign slug = include.page.url | split: "/" | last %}
   {% assign synonyms = site.pages | where_exp: "item": "item.destination == slug" %}
   {% if synonyms.size > 0 %}
-  <h2>Synonyms</h2>
+  <{{header}}>Synonyms</{{header}}>
   <ul>
   {% for synonym in synonyms %}
     <li>{{ synonym.title }}</li>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -9,7 +9,11 @@ layout: compress
     </div>
   </div>
   <h1 class="f3 f2-m f1-l">{{ page.title }}</h1>
-  {{ content }}
+  {% if page.toc %}
+    {{ content | toc }}
+  {% else %}
+    {{ content }}
+  {% endif %}
   {% include synonyms.html page=page %}
   {% include related_terms.html page=page %}
   {% include references.html page=page %}

--- a/all.html
+++ b/all.html
@@ -1,22 +1,26 @@
 ---
 layout: page
 title: All Words
+toc: true
 ---
 {% assign terms = site.pages | where_exp:"item","item.url contains 'terms/'" %}
-{% for term in terms %}
-  {% if term.title %}
-    {% assign link_name = term.url | split: "/" | last %}
-    <h1><a name="{{ link_name }}" href="{{ term.url }}">{{ term.title }}</a></h1>
-    {% if term.layout == "redirect" %}
-      {% assign destination_url = "/terms/" | append: term.destination | append: "/" %}
-      {% assign destination = terms | where_exp: "item": "item.url == destination_url" | first %}
-      See <a href="#{{ term.destination }}">{{ destination.title }}</a>.
-    {% else %}
-      {{ term.content | markdownify }}
-      {% include synonyms.html page=term %}
-      {% include related_terms.html page=term local=true %}
-      {% include references.html page=term %}
+{% capture all_content %}
+  {% for term in terms %}
+    {% if term.title %}
+      {% assign link_name = term.url | split: "/" | last %}
+      <h1><a name="{{ link_name }}" href="{{ term.url }}">{{ term.title }}</a></h1>
+      {% if term.layout == "redirect" %}
+        {% assign destination_url = "/terms/" | append: term.destination | append: "/" %}
+        {% assign destination = terms | where_exp: "item": "item.url == destination_url" | first %}
+        See <a href="#{{ term.destination }}">{{ destination.title }}</a>.
+      {% else %}
+        {{ term.content | markdownify }}
+        {% include synonyms.html page=term header="h4" %}
+        {% include related_terms.html page=term local=true header="h4" %}
+        {% include references.html page=term header="h4" %}
+      {% endif %}
+      <hr />
     {% endif %}
-    <hr />
-  {% endif %}
-{% endfor %}
+  {% endfor %}
+{% endcapture %}
+{{ all_content }}


### PR DESCRIPTION
(Work-in-progress. Do not land on master.)

We had previously installed the `jekyll-toc` plugin, but were not
generating tables of contents for our terms. Now we have the option
to do that.