### PR TITLE
Only use Netlify Identity JavaScript on the homepage

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -18,9 +18,5 @@
   ga('send', 'pageview');
 
 </script>
-<script type="text/javascript">
-if (window.netlifyIdentity) { window.netlifyIdentity.on("init", function (user) { if (!user) { window.netlifyIdentity.on("login",
-function () { document.location.href = "/admin/"; }); } }); }
-</script>
 </body>
 </html>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,8 +10,6 @@
       <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
         <title>{{ page.title }} - {{ site.title }}</title>
         <link rel="stylesheet" href="/css/customstyle.css"/>
-        <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
-
         <script type="text/javascript" async
   src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_CHTML">
 </script>

--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -2,6 +2,7 @@
 layout: compress
 ---
 {% include header.html %}
+<script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
 {% assign pages = site.pages | where_exp:"item","item.url contains 'terms/'" | sort_natural: 'title' %}
 {% capture term_list %}
 {% for page in pages %}
@@ -37,4 +38,14 @@ layout: compress
     </article>
   </div>
 </div>
+<script type="text/javascript">
+  if (window.netlifyIdentity) {
+    window.netlifyIdentity.on("init", function (user) {
+      if (!user) {
+        window.netlifyIdentity.on("login",
+          function () { document.location.href = "/admin/"; });
+      }
+    });
+  }
+</script>
 {% include footer.html %}


### PR DESCRIPTION
We don't need the Netlify identity stuff on the term
pages, so that should lead to faster page load if
people go directly to a term page from Google.